### PR TITLE
feat(web): infinite-scroll pagination with prefetch and in-place row refresh

### DIFF
--- a/web/components/common/InfiniteScrollSentinel.tsx
+++ b/web/components/common/InfiniteScrollSentinel.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useRef, useState } from 'react'
+
+type InfiniteScrollSentinelProps = {
+  onLoadMore: () => void,
+  hasMore: boolean,
+  isFetchingMore: boolean,
+  /** Distance from the viewport at which loading kicks in. Defaults to 800px. */
+  rootMargin?: string,
+  className?: string,
+}
+
+/**
+ * Invisible marker that triggers `onLoadMore` as it approaches the viewport.
+ * The generous root margin loads the next window before the user reaches the
+ * bottom, which keeps scrolling smooth on touch devices. Intersection state is
+ * tracked so loading continues even when the marker stays in view after a page
+ * resolves.
+ */
+export function InfiniteScrollSentinel({
+  onLoadMore,
+  hasMore,
+  isFetchingMore,
+  rootMargin = '800px',
+  className,
+}: InfiniteScrollSentinelProps) {
+  const ref = useRef<HTMLDivElement | null>(null)
+  const [isIntersecting, setIsIntersecting] = useState(false)
+
+  useEffect(() => {
+    const node = ref.current
+    if (!node || typeof IntersectionObserver === 'undefined') return
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0]
+        if (entry) setIsIntersecting(entry.isIntersecting)
+      },
+      { rootMargin }
+    )
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [rootMargin])
+
+  const onLoadMoreRef = useRef(onLoadMore)
+  onLoadMoreRef.current = onLoadMore
+
+  useEffect(() => {
+    if (isIntersecting && hasMore && !isFetchingMore) {
+      onLoadMoreRef.current()
+    }
+  }, [isIntersecting, hasMore, isFetchingMore])
+
+  if (!hasMore) return null
+
+  return <div ref={ref} aria-hidden className={className} />
+}

--- a/web/components/tables/PatientList.tsx
+++ b/web/components/tables/PatientList.tsx
@@ -1,9 +1,9 @@
 import { useMemo, useState, forwardRef, useImperativeHandle, useEffect, useCallback, useRef, type ReactNode } from 'react'
 import { useMutation } from '@apollo/client/react'
 import type { IdentifierFilterValue, FilterListItem, FilterListPopUpBuilderProps } from '@helpwave/hightide'
-import { Chip, FillerCell, HelpwaveLogo, LoadingContainer, SearchBar, ProgressIndicator, Tooltip, Drawer, TableProvider, TableDisplay, TableColumnSwitcher, IconButton, useLocale, FilterList, SortingList, Button, ExpansionIcon, Visibility, ConfirmDialog } from '@helpwave/hightide'
+import { Chip, FillerCell, HelpwaveLogo, SearchBar, ProgressIndicator, Tooltip, Drawer, TableProvider, TableDisplay, TableColumnSwitcher, IconButton, useLocale, FilterList, SortingList, Button, ExpansionIcon, Visibility, ConfirmDialog } from '@helpwave/hightide'
 import clsx from 'clsx'
-import { LayoutGrid, PlusIcon, Table2 } from 'lucide-react'
+import { LayoutGrid, Loader2, PlusIcon, Table2 } from 'lucide-react'
 import type { LocationType } from '@/api/gql/generated'
 import { Sex, PatientState, type GetPatientsQuery, type TaskType, PropertyEntity, FieldType, type QueryableField } from '@/api/gql/generated'
 import { usePropertyDefinitions, usePatientsPaginated, useQueryableFields, useRefreshingEntityIds, useUpdatePatient } from '@/data'
@@ -20,6 +20,8 @@ import { getPropertyColumnIds, useColumnVisibilityWithPropertyDefaults } from '@
 import { columnFiltersToQueryFilterClauses, sortingStateToQuerySortClauses } from '@/utils/tableStateToApi'
 import { LIST_PAGE_SIZE } from '@/utils/listPaging'
 import { useAccumulatedPagination } from '@/hooks/useAccumulatedPagination'
+import { RowRefreshingGate } from '@/components/tables/RowRefreshingGate'
+import { InfiniteScrollSentinel } from '@/components/common/InfiniteScrollSentinel'
 import { DateDisplay } from '@/components/Date/DateDisplay'
 import { PatientCardView } from '@/components/patients/PatientCardView'
 import { queryableFieldsToFilterListItems, queryableFieldsToSortingListItems, type QueryableChoiceTagLabelResolver } from '@/utils/queryableFilterList'
@@ -378,7 +380,7 @@ export const PatientList = forwardRef<PatientListRef, PatientListProps>(({ initi
   )
 
   const lastTotalCountRef = useRef<number | undefined>(undefined)
-  const { data: patientsData, refetch, totalCount, loading: patientsLoading } = usePatientsPaginated(
+  const { data: patientsData, refetch, totalCount, loading: patientsLoading, prefetchPage } = usePatientsPaginated(
     {
       locationId: hasLocationFilter ? undefined : (locationId || undefined),
       rootLocationIds: hasLocationFilter || locationId
@@ -397,13 +399,15 @@ export const PatientList = forwardRef<PatientListRef, PatientListProps>(({ initi
   if (totalCount != null) lastTotalCountRef.current = totalCount
   const stableTotalCount = totalCount ?? lastTotalCountRef.current
 
-  const { accumulated: accumulatedPatientsRaw, loadMore, hasMore } = useAccumulatedPagination({
+  const { accumulated: accumulatedPatientsRaw, loadMore, hasMore, isFetchingMore } = useAccumulatedPagination({
     resetKey: accumulationResetKey,
     pageData: patientsData,
     pageIndex: fetchPageIndex,
     setPageIndex: setFetchPageIndex,
     totalCount: stableTotalCount,
     loading: patientsLoading,
+    pageSize: LIST_PAGE_SIZE,
+    prefetchPage,
   })
 
   const mapPatientRow = useCallback((p: GetPatientsQuery['patients'][0]): PatientViewModel => {
@@ -587,14 +591,19 @@ export const PatientList = forwardRef<PatientListRef, PatientListProps>(({ initi
     day: '2-digit'
   }), [locale])
 
-  const rowLoadingCell = useMemo(() => <LoadingContainer className="w-full min-h-8" />, [])
+  const gateCell = useCallback(
+    (patientId: string, content: ReactNode) => (
+      <RowRefreshingGate refreshing={refreshingPatientIds.has(patientId)}>{content}</RowRefreshingGate>
+    ),
+    [refreshingPatientIds]
+  )
 
   const columns = useMemo<ColumnDef<PatientViewModel>[]>(() => [
     {
       id: 'name',
       header: translation('name'),
       accessorKey: 'name',
-      cell: ({ row }) => (refreshingPatientIds.has(row.original.id) ? rowLoadingCell : row.original.name),
+      cell: ({ row }) => gateCell(row.original.id, row.original.name),
       minSize: 200,
       size: 250,
       maxSize: 300,
@@ -603,15 +612,12 @@ export const PatientList = forwardRef<PatientListRef, PatientListProps>(({ initi
       id: 'state',
       header: translation('status'),
       accessorFn: ({ state }) => state,
-      cell: ({ row }) => {
-        if (refreshingPatientIds.has(row.original.id)) return rowLoadingCell
-        return (
-          <>
-            <span className="print:block hidden">{translation('patientState', { state: row.original.state as string })}</span>
-            <PatientStateChip state={row.original.state} className="print:hidden" />
-          </>
-        )
-      },
+      cell: ({ row }) => gateCell(row.original.id, (
+        <>
+          <span className="print:block hidden">{translation('patientState', { state: row.original.state as string })}</span>
+          <PatientStateChip state={row.original.state} className="print:hidden" />
+        </>
+      )),
       minSize: 120,
       size: 144,
       maxSize: 180,
@@ -621,7 +627,6 @@ export const PatientList = forwardRef<PatientListRef, PatientListProps>(({ initi
       header: translation('sex'),
       accessorFn: ({ sex }) => sex,
       cell: ({ row }) => {
-        if (refreshingPatientIds.has(row.original.id)) return rowLoadingCell
         const sex = row.original.sex
         const colorClass = sex === Sex.Male
           ? 'gender-male'
@@ -635,7 +640,7 @@ export const PatientList = forwardRef<PatientListRef, PatientListProps>(({ initi
           [Sex.Unknown]: translation('diverse'),
         }[sex] || sex
 
-        return (
+        return gateCell(row.original.id, (
           <>
             <span className="print:block hidden">{label}</span>
             <Chip
@@ -647,7 +652,7 @@ export const PatientList = forwardRef<PatientListRef, PatientListProps>(({ initi
               <span>{label}</span>
             </Chip>
           </>
-        )
+        ))
       },
       minSize: 160,
       size: 160,
@@ -658,9 +663,8 @@ export const PatientList = forwardRef<PatientListRef, PatientListProps>(({ initi
       header: translation('clinic'),
       accessorFn: ({ clinic }: PatientViewModel) => clinic?.title,
       cell: ({ row }: { row: Row<PatientViewModel> }) => {
-        if (refreshingPatientIds.has(row.original.id)) return rowLoadingCell
         const clinic = row.original.clinic
-        return (
+        return gateCell(row.original.id, (
           <>
             <span className="print:block hidden">{clinic?.title}</span>
             <LocationChips
@@ -669,7 +673,7 @@ export const PatientList = forwardRef<PatientListRef, PatientListProps>(({ initi
               className="print:hidden"
             />
           </>
-        )
+        ))
       },
       minSize: 160,
       size: 220,
@@ -679,15 +683,12 @@ export const PatientList = forwardRef<PatientListRef, PatientListProps>(({ initi
       id: 'position',
       header: translation('location'),
       accessorFn: ({ position }: PatientViewModel) => position?.title,
-      cell: ({ row }: { row: Row<PatientViewModel> }) => {
-        if (refreshingPatientIds.has(row.original.id)) return rowLoadingCell
-        return (
-          <>
-            <span className="print:block hidden">{row.original.position?.title}</span>
-            <LocationChipsBySetting locations={row.original.position ? [row.original.position] : []} small className="print:hidden" />
-          </>
-        )
-      },
+      cell: ({ row }: { row: Row<PatientViewModel> }) => gateCell(row.original.id, (
+        <>
+          <span className="print:block hidden">{row.original.position?.title}</span>
+          <LocationChipsBySetting locations={row.original.position ? [row.original.position] : []} small className="print:hidden" />
+        </>
+      )),
       minSize: 200,
       size: 260,
       maxSize: 320,
@@ -700,15 +701,14 @@ export const PatientList = forwardRef<PatientListRef, PatientListProps>(({ initi
         return byKind[kind]?.title ?? ''
       },
       cell: ({ row }: { row: Row<PatientViewModel> }) => {
-        if (refreshingPatientIds.has(row.original.id)) return rowLoadingCell
         const byKind = getLocationNodesByKind(row.original.position ?? null)
         const node = byKind[kind]
-        return (
+        return gateCell(row.original.id, (
           <>
             <span className="print:block hidden">{node?.title}</span>
             <LocationChips locations={node ? [{ id: node.id, title: node.title, kind: node.kind as LocationType }] : []} small className="print:hidden" />
           </>
-        )
+        ))
       },
       minSize: 160,
       size: 220,
@@ -719,9 +719,6 @@ export const PatientList = forwardRef<PatientListRef, PatientListProps>(({ initi
       header: translation('birthdate'),
       accessorKey: 'birthdate',
       cell: ({ row }) => {
-        if (refreshingPatientIds.has(row.original.id))
-          return rowLoadingCell
-
         const now = new Date()
         const birthdate = row.original.birthdate
         let years = now.getFullYear() - birthdate.getFullYear()
@@ -732,11 +729,11 @@ export const PatientList = forwardRef<PatientListRef, PatientListProps>(({ initi
           years--
         }
 
-        return (
+        return gateCell(row.original.id, (
           <span>
             {dateFormat.format(row.original.birthdate) + ' (' + translation('nYears', { years }) + ')'}
           </span>
-        )
+        ))
       },
       minSize: 200,
       size: 200,
@@ -750,12 +747,11 @@ export const PatientList = forwardRef<PatientListRef, PatientListProps>(({ initi
         return total === 0 ? 0 : closedTasksCount / total
       },
       cell: ({ row }) => {
-        if (refreshingPatientIds.has(row.original.id)) return rowLoadingCell
         const { openTasksCount, closedTasksCount } = row.original
         const total = openTasksCount + closedTasksCount
         const progress = total === 0 ? 0 : closedTasksCount / total
 
-        return (
+        return gateCell(row.original.id, (
           <Tooltip
             tooltip={(
               <div className="flex-col-0">
@@ -769,7 +765,7 @@ export const PatientList = forwardRef<PatientListRef, PatientListProps>(({ initi
               <ProgressIndicator progress={progress} rotation={-90} />
             </div>
           </Tooltip>
-        )
+        ))
       },
       minSize: 150,
       size: 150,
@@ -787,15 +783,13 @@ export const PatientList = forwardRef<PatientListRef, PatientListProps>(({ initi
         return updateDates[0]
       },
       cell: ({ row }) => {
-        if (refreshingPatientIds.has(row.original.id)) return rowLoadingCell
         const taskList = row.original.tasks || []
         const updateDates = taskList
           .map(t => t.updateDate ? new Date(t.updateDate) : null)
           .filter((d): d is Date => d !== null)
           .sort((a, b) => b.getTime() - a.getTime())
         const d = updateDates[0]
-        if (!d) return <FillerCell />
-        return <DateDisplay date={d} mode="absolute" />
+        return gateCell(row.original.id, d ? <DateDisplay date={d} mode="absolute" /> : <FillerCell />)
       },
       minSize: 220,
       size: 220,
@@ -806,10 +800,10 @@ export const PatientList = forwardRef<PatientListRef, PatientListProps>(({ initi
       ...col,
       cell: col.cell
         ? (params: { row: { original: PatientViewModel } }) =>
-          refreshingPatientIds.has(params.row.original.id) ? rowLoadingCell : (col.cell as (p: unknown) => React.ReactNode)(params)
+          gateCell(params.row.original.id, (col.cell as (p: unknown) => React.ReactNode)(params))
         : undefined,
     })),
-  ], [translation, patientPropertyColumnsWithActions, refreshingPatientIds, rowLoadingCell, dateFormat])
+  ], [translation, patientPropertyColumnsWithActions, gateCell, dateFormat])
 
   const propertyFieldTypeByDefId = useMemo(
     () => new Map(propertyDefinitionsData?.propertyDefinitions.map(d => [d.id, d.fieldType]) ?? []),
@@ -1176,10 +1170,24 @@ export const PatientList = forwardRef<PatientListRef, PatientListProps>(({ initi
               ))}
             </div>
           )}
-          {stableTotalCount != null && hasMore && !embedded && !derivedVirtualMode && (
-            <Button color="neutral" className="mt-2 w-full sm:w-auto self-center" onClick={loadMore}>
-              {translation('loadMore')}
-            </Button>
+          {!embedded && !derivedVirtualMode && (
+            <>
+              <InfiniteScrollSentinel
+                onLoadMore={loadMore}
+                hasMore={stableTotalCount != null && hasMore}
+                isFetchingMore={isFetchingMore}
+              />
+              {isFetchingMore && (
+                <div className="flex justify-center py-2 print:hidden" aria-busy>
+                  <Loader2 className="size-5 animate-spin text-description" />
+                </div>
+              )}
+              {stableTotalCount != null && hasMore && !isFetchingMore && (
+                <Button color="neutral" className="mt-2 w-full sm:w-auto self-center print:hidden" onClick={loadMore}>
+                  {translation('loadMore')}
+                </Button>
+              )}
+            </>
           )}
         </div>
         <Drawer

--- a/web/components/tables/RowRefreshingGate.tsx
+++ b/web/components/tables/RowRefreshingGate.tsx
@@ -1,0 +1,31 @@
+import type { HTMLAttributes, ReactNode } from 'react'
+import { Loader2 } from 'lucide-react'
+import clsx from 'clsx'
+
+type RowRefreshingGateProps = HTMLAttributes<HTMLDivElement> & {
+  refreshing: boolean,
+  children: ReactNode,
+}
+
+/**
+ * Keeps the cell content visible while an entity is being refreshed, dimming it
+ * and overlaying a spinner instead of replacing it with a loading placeholder.
+ */
+export function RowRefreshingGate({ refreshing, children, className, ...restProps }: RowRefreshingGateProps) {
+  return (
+    <div className={clsx('relative min-h-8 min-w-0', className)} {...restProps}>
+      <div className={refreshing ? 'opacity-50' : undefined}>
+        {children}
+      </div>
+      {refreshing && (
+        <div
+          className="pointer-events-none absolute inset-0 z-[1] flex items-center justify-center bg-surface/25"
+          aria-busy
+          aria-hidden
+        >
+          <Loader2 className="size-4 shrink-0 animate-spin text-description" />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/components/tables/TaskList.tsx
+++ b/web/components/tables/TaskList.tsx
@@ -3,7 +3,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import type { FilterListItem } from '@helpwave/hightide'
 import { Button, Checkbox, ConfirmDialog, FilterList, FillerCell, HelpwaveLogo, IconButton, SearchBar, TableColumnSwitcher, TableDisplay, TableProvider, SortingList, ExpansionIcon } from '@helpwave/hightide'
 import clsx from 'clsx'
-import { Edit2, ExternalLink, LayoutGrid, PlusIcon, Table2, UserCheck } from 'lucide-react'
+import { Edit2, ExternalLink, LayoutGrid, Loader2, PlusIcon, Table2, UserCheck } from 'lucide-react'
 import type { IdentifierFilterValue } from '@helpwave/hightide'
 import type { TaskPriority, GetTasksQuery, QueryableField } from '@/api/gql/generated'
 import { FieldType, PropertyEntity } from '@/api/gql/generated'
@@ -30,6 +30,7 @@ import { queryableFieldsToFilterListItems, queryableFieldsToSortingListItems, ty
 import { LIST_PAGE_SIZE } from '@/utils/listPaging'
 import { TaskCardView } from '@/components/tasks/TaskCardView'
 import { RefreshingTaskIdsContext, TaskRowRefreshingGate } from '@/components/tables/TaskRowRefreshingGate'
+import { InfiniteScrollSentinel } from '@/components/common/InfiniteScrollSentinel'
 import { ExpandableTextBlock } from '@/components/common/ExpandableTextBlock'
 import { InTableTextEditPopUp } from '@/components/tables/in-table-edit/InTableTextEditPopUp'
 import { InTableDateTimeEditPopUp } from './in-table-edit/InTableDateTimeEditPopUp'
@@ -104,12 +105,13 @@ type TaskListProps = {
   onSearchQueryChange?: (value: string) => void,
   loadMore?: () => void,
   hasMore?: boolean,
+  isFetchingMore?: boolean,
   embedded?: boolean,
   /** Row order and search already applied in parent (e.g. saved view derived task list). */
   virtualDerivedOrder?: boolean,
 }
 
-export const TaskList = forwardRef<TaskListRef, TaskListProps>(({ tasks: initialTasks, onRefetch, showAssignee = false, initialTaskId, onInitialTaskOpened, headerActions, saveViewSlot, totalCount, loading = false, tableState: controlledTableState, searchQuery: searchQueryProp, onSearchQueryChange, loadMore: loadMoreProp, hasMore: hasMoreProp, embedded = false, virtualDerivedOrder = false }, ref) => {
+export const TaskList = forwardRef<TaskListRef, TaskListProps>(({ tasks: initialTasks, onRefetch, showAssignee = false, initialTaskId, onInitialTaskOpened, headerActions, saveViewSlot, totalCount, loading = false, tableState: controlledTableState, searchQuery: searchQueryProp, onSearchQueryChange, loadMore: loadMoreProp, hasMore: hasMoreProp, isFetchingMore = false, embedded = false, virtualDerivedOrder = false }, ref) => {
   const translation = useTasksTranslation()
   const { data: propertyDefinitionsData } = usePropertyDefinitions()
   const { data: queryableFieldsData } = useQueryableFields('Task')
@@ -1089,10 +1091,24 @@ export const TaskList = forwardRef<TaskListRef, TaskListProps>(({ tasks: initial
                 ))}
               </div>
             )}
-            {effectiveHasMore && !embedded && (
-              <Button color="neutral" className="mt-2 w-full sm:w-auto self-center" onClick={handleLoadMore}>
-                {translation('loadMore')}
-              </Button>
+            {!embedded && (
+              <>
+                <InfiniteScrollSentinel
+                  onLoadMore={handleLoadMore}
+                  hasMore={effectiveHasMore}
+                  isFetchingMore={isFetchingMore}
+                />
+                {isFetchingMore && (
+                  <div className="flex justify-center py-2 print:hidden" aria-busy>
+                    <Loader2 className="size-5 animate-spin text-description" />
+                  </div>
+                )}
+                {effectiveHasMore && !isFetchingMore && (
+                  <Button color="neutral" className="mt-2 w-full sm:w-auto self-center print:hidden" onClick={handleLoadMore}>
+                    {translation('loadMore')}
+                  </Button>
+                )}
+              </>
             )}
           </div>
           <Drawer

--- a/web/components/tables/TaskRowRefreshingGate.tsx
+++ b/web/components/tables/TaskRowRefreshingGate.tsx
@@ -1,7 +1,6 @@
 import type { HTMLAttributes } from 'react'
 import { createContext, useContext, type ReactNode } from 'react'
-import { Loader2 } from 'lucide-react'
-import clsx from 'clsx'
+import { RowRefreshingGate } from './RowRefreshingGate'
 
 const EMPTY_TASK_IDS = new Set<string>()
 
@@ -12,23 +11,11 @@ type TaskRowRefreshingGateProps = HTMLAttributes<HTMLDivElement> & {
   children: ReactNode,
 }
 
-export function TaskRowRefreshingGate({ taskId, children, className, ...restProps }: TaskRowRefreshingGateProps) {
+export function TaskRowRefreshingGate({ taskId, children, ...restProps }: TaskRowRefreshingGateProps) {
   const ids = useContext(RefreshingTaskIdsContext)
-  const refreshing = ids.has(taskId)
   return (
-    <div className={clsx('relative min-h-8 min-w-0', className)} {...restProps}>
-      <div className={refreshing ? 'opacity-50' : undefined}>
-        {children}
-      </div>
-      {refreshing && (
-        <div
-          className="pointer-events-none absolute inset-0 z-[1] flex items-center justify-center bg-surface/25"
-          aria-busy
-          aria-hidden
-        >
-          <Loader2 className="size-4 shrink-0 animate-spin text-description" />
-        </div>
-      )}
-    </div>
+    <RowRefreshingGate refreshing={ids.has(taskId)} {...restProps}>
+      {children}
+    </RowRefreshingGate>
   )
 }

--- a/web/data/hooks/usePaginatedEntityQuery.ts
+++ b/web/data/hooks/usePaginatedEntityQuery.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useRef } from 'react'
-import { useQueryWhenReady } from './queryHelpers'
+import { useQueryWhenReady, getParsedDocument } from './queryHelpers'
+import { useApolloClientOptional } from '@/providers/ApolloProviderWithData'
 import type { QueryFilterClauseInput, QuerySearchInput, QuerySortClauseInput } from '@/api/gql/generated'
 
 export type UsePaginatedEntityQueryOptions<TQueryData> = {
@@ -17,6 +18,8 @@ export type UsePaginatedEntityQueryResult<TItem> = {
   error: Error | undefined,
   totalCount: number | undefined,
   refetch: () => void,
+  /** Warm the Apollo cache for an arbitrary page without affecting the active query. */
+  prefetchPage: (pageIndex: number) => void,
 }
 
 type VariablesWithPagination = {
@@ -38,13 +41,16 @@ export function usePaginatedEntityQuery<
   extractTotal: (data: TQueryData | undefined) => number | undefined
 ): UsePaginatedEntityQueryResult<TItem> {
   const { pagination, sorts, filters, search, skip: skipQuery } = options
-  const variablesWithPagination = useMemo(() => ({
+  const baseVariables = useMemo(() => ({
     ...(variables ?? {}),
-    pagination: { pageIndex: pagination.pageIndex, pageSize: pagination.pageSize },
     ...(sorts != null && sorts.length > 0 ? { sorts } : {}),
     ...(filters != null && filters.length > 0 ? { filters } : {}),
     ...(search != null && search.searchText ? { search } : {}),
-  }), [variables, pagination.pageIndex, pagination.pageSize, sorts, filters, search])
+  }), [variables, sorts, filters, search])
+  const variablesWithPagination = useMemo(() => ({
+    ...baseVariables,
+    pagination: { pageIndex: pagination.pageIndex, pageSize: pagination.pageSize },
+  }), [baseVariables, pagination.pageIndex, pagination.pageSize])
   const variablesTyped = variablesWithPagination as TVariables & VariablesWithPagination
   const result = useQueryWhenReady<TQueryData, TVariables & VariablesWithPagination>(
     document,
@@ -64,11 +70,23 @@ export function usePaginatedEntityQuery<
     result.refetch()
   }, [result])
 
+  const client = useApolloClientOptional()
+  const pageSize = pagination.pageSize
+  const prefetchPage = useCallback((pageIndex: number) => {
+    if (!client || skipQuery === true || pageIndex < 0) return
+    void client.query({
+      query: getParsedDocument(document),
+      variables: { ...baseVariables, pagination: { pageIndex, pageSize } },
+      fetchPolicy: 'cache-first',
+    }).catch(() => {})
+  }, [client, skipQuery, document, baseVariables, pageSize])
+
   return {
     data,
     loading: result.loading,
     error: result.error,
     totalCount,
     refetch,
+    prefetchPage,
   }
 }

--- a/web/data/hooks/usePatientsPaginated.ts
+++ b/web/data/hooks/usePatientsPaginated.ts
@@ -20,6 +20,7 @@ export type UsePatientsPaginatedResult = {
   error: Error | undefined,
   totalCount: number | undefined,
   refetch: () => void,
+  prefetchPage: (pageIndex: number) => void,
 }
 
 function propertyFingerprint(prop: { definition?: { id: string }, textValue?: string | null, numberValue?: number | null, userValue?: string | null }): string {

--- a/web/data/hooks/useTasksPaginated.ts
+++ b/web/data/hooks/useTasksPaginated.ts
@@ -19,6 +19,7 @@ export type UseTasksPaginatedResult = {
   error: Error | undefined,
   totalCount: number | undefined,
   refetch: () => void,
+  prefetchPage: (pageIndex: number) => void,
 }
 
 export function useTasksPaginated(

--- a/web/hooks/useAccumulatedPagination.ts
+++ b/web/hooks/useAccumulatedPagination.ts
@@ -1,4 +1,16 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+const DEFAULT_PREFETCH_PAGES = 2
+
+function reconcileFirstPage<T extends { id: string }>(prev: T[], incoming: T[]): T[] {
+  // When more pages were already accumulated, keep the tail and only refresh the
+  // leading page so a page-0 background refetch never shrinks the visible list.
+  if (incoming.length === 0) return prev
+  if (prev.length <= incoming.length) return incoming
+  const incomingIds = new Set(incoming.map(x => x.id))
+  const tail = prev.filter(item => !incomingIds.has(item.id))
+  return [...incoming, ...tail]
+}
 
 export function useAccumulatedPagination<T extends { id: string }>(options: {
   resetKey: string,
@@ -7,12 +19,21 @@ export function useAccumulatedPagination<T extends { id: string }>(options: {
   setPageIndex: React.Dispatch<React.SetStateAction<number>>,
   totalCount: number | undefined,
   loading: boolean,
+  pageSize: number,
+  /** Warms the cache for upcoming pages so scrolling stays instant. */
+  prefetchPage?: (pageIndex: number) => void,
+  /** How many pages ahead to keep ready. Defaults to 2. */
+  prefetchPages?: number,
 }): {
   accumulated: T[],
   loadMore: () => void,
   hasMore: boolean,
+  isFetchingMore: boolean,
 } {
-  const { resetKey, pageData, pageIndex, setPageIndex, totalCount, loading } = options
+  const {
+    resetKey, pageData, pageIndex, setPageIndex, totalCount, loading,
+    pageSize, prefetchPage, prefetchPages = DEFAULT_PREFETCH_PAGES,
+  } = options
   const [accumulated, setAccumulated] = useState<T[]>([])
   const prevResetKeyRef = useRef(resetKey)
 
@@ -27,7 +48,9 @@ export function useAccumulatedPagination<T extends { id: string }>(options: {
   useEffect(() => {
     if (pageData === undefined || loading) return
     if (pageIndex === 0) {
-      setAccumulated(pageData)
+      // Reconcile the first page in place so unchanged rows keep their position
+      // and the table is not remounted on every background refetch.
+      setAccumulated(prev => reconcileFirstPage(prev, pageData))
       return
     }
     setAccumulated(prev => {
@@ -40,11 +63,27 @@ export function useAccumulatedPagination<T extends { id: string }>(options: {
     })
   }, [pageData, pageIndex, loading])
 
+  const hasMore = totalCount != null && accumulated.length < totalCount
+  const isFetchingMore = loading && pageIndex > 0
+
   const loadMore = useCallback(() => {
     setPageIndex(i => i + 1)
   }, [setPageIndex])
 
-  const hasMore = totalCount != null && accumulated.length < totalCount
+  const lastLoadedPage = useMemo(() => {
+    if (pageSize <= 0) return pageIndex
+    return Math.max(pageIndex, Math.ceil(accumulated.length / pageSize) - 1)
+  }, [pageIndex, accumulated.length, pageSize])
 
-  return { accumulated, loadMore, hasMore }
+  useEffect(() => {
+    if (!prefetchPage || loading || totalCount == null || pageSize <= 0) return
+    const lastAvailablePage = Math.ceil(totalCount / pageSize) - 1
+    for (let i = 1; i <= prefetchPages; i++) {
+      const target = lastLoadedPage + i
+      if (target > lastAvailablePage) break
+      prefetchPage(target)
+    }
+  }, [prefetchPage, prefetchPages, lastLoadedPage, totalCount, pageSize, loading])
+
+  return { accumulated, loadMore, hasMore, isFetchingMore }
 }

--- a/web/pages/tasks/index.tsx
+++ b/web/pages/tasks/index.tsx
@@ -107,7 +107,7 @@ const TasksPage: NextPage = () => {
     [apiFilters, apiSorting, searchInput, selectedRootLocationIds, user?.id]
   )
 
-  const { data: tasksData, refetch, totalCount, loading: tasksLoading } = useTasksPaginated(
+  const { data: tasksData, refetch, totalCount, loading: tasksLoading, prefetchPage } = useTasksPaginated(
     !!selectedRootLocationIds && !!user
       ? { rootLocationIds: selectedRootLocationIds, assigneeId: user?.id }
       : undefined,
@@ -119,13 +119,15 @@ const TasksPage: NextPage = () => {
     }
   )
 
-  const { accumulated: accumulatedTasksRaw, loadMore, hasMore } = useAccumulatedPagination({
+  const { accumulated: accumulatedTasksRaw, loadMore, hasMore, isFetchingMore } = useAccumulatedPagination({
     resetKey: accumulationResetKey,
     pageData: tasksData,
     pageIndex: fetchPageIndex,
     setPageIndex: setFetchPageIndex,
     totalCount,
     loading: tasksLoading,
+    pageSize: LIST_PAGE_SIZE,
+    prefetchPage,
   })
 
   const taskId = router.query['taskId'] as string | undefined
@@ -195,6 +197,7 @@ const TasksPage: NextPage = () => {
           onSearchQueryChange={setSearchQuery}
           loadMore={loadMore}
           hasMore={hasMore}
+          isFetchingMore={isFetchingMore}
           saveViewSlot={(
             <Visibility isVisible={hasUnsavedViewChanges}>
               <SaveViewActionsMenu

--- a/web/pages/view/[uid].tsx
+++ b/web/pages/view/[uid].tsx
@@ -268,7 +268,7 @@ function SavedTaskViewTab({
     [apiFilters, apiSorting, searchInput, rootIds, assigneeId]
   )
 
-  const { data: tasksData, refetch, totalCount, loading: tasksLoading } = useTasksPaginated(
+  const { data: tasksData, refetch, totalCount, loading: tasksLoading, prefetchPage } = useTasksPaginated(
     rootIds && assigneeId
       ? { rootLocationIds: rootIds, assigneeId }
       : undefined,
@@ -280,13 +280,15 @@ function SavedTaskViewTab({
     }
   )
 
-  const { accumulated: accumulatedTasksRaw, loadMore, hasMore } = useAccumulatedPagination({
+  const { accumulated: accumulatedTasksRaw, loadMore, hasMore, isFetchingMore } = useAccumulatedPagination({
     resetKey: accumulationResetKey,
     pageData: tasksData,
     pageIndex: fetchPageIndex,
     setPageIndex: setFetchPageIndex,
     totalCount,
     loading: tasksLoading,
+    pageSize: LIST_PAGE_SIZE,
+    prefetchPage,
   })
 
   const tasks: TaskViewModel[] = useMemo(() => {
@@ -358,6 +360,7 @@ function SavedTaskViewTab({
         ) : undefined}
         loadMore={loadMore}
         hasMore={hasMore}
+        isFetchingMore={isFetchingMore}
         tableState={{
           sorting,
           setSorting,


### PR DESCRIPTION
## Summary

Reworks the task & patient table pagination and live-update UX so the list no longer jumps or shows per-cell loaders on entity updates, and loads more rows automatically as you scroll.

Addresses three of the reported table issues:
- **Stay at the same point on update** — a background page-0 refetch (fired by the subscription layer on every entity update) no longer collapses the accumulated list or remounts the table.
- **Show content, not loaders, during refresh** — refreshing rows dim with a spinner overlay instead of replacing every cell with a `LoadingContainer`; the blocking loader only appears on the initial empty load.
- **Auto-load on scroll with a sliding window** — infinite scroll that prefetches the next 2 pages ahead so scrolling stays instant (helps touch/iOS smoothness).

## Changes

- **`usePaginatedEntityQuery`**: expose `prefetchPage(i)` that warms the Apollo cache for an arbitrary page (`cache-first`) without disturbing the active query; threaded through `useTasksPaginated` / `usePatientsPaginated`.
- **`useAccumulatedPagination`**: prefetch the next pages ahead (default 2), expose `isFetchingMore`, and reconcile the first page in place so a page-0 background refetch never shrinks the visible list.
- **`InfiniteScrollSentinel`** (new): `IntersectionObserver` marker (800px root margin) that loads the next window before the user reaches the bottom; tracks intersection state so it keeps loading while it stays in view. SSR-guarded.
- **`RowRefreshingGate`** (new, generic): dim + spinner overlay that keeps cell content visible during refresh. `TaskRowRefreshingGate` now wraps it; `PatientList` uses it instead of swapping every cell for a `LoadingContainer`.
- Wire the sentinel + fetching indicator into `TaskList` and `PatientList`; the "Load more" button remains as an accessible fallback.

## Validation

- `npm run lint` (tsc --noEmit + eslint) ✅
- `npm run check-translations` ✅
- `npm run build` ✅

⚠️ Not run in this environment: Playwright E2E and live runtime (require the full stack: Postgres/Redis/Keycloak/InfluxDB + backend). Worth a manual scroll/refresh pass before merge.

## Known follow-up (separate PR)

Accumulated pages are React snapshots, so an entity updated on a page other than the active one only re-renders live when its page is refetched — a pre-existing limitation of the client-accumulate design. The clean fix is a relay-style Apollo field-policy merge (one normalized query across pages), which I'll do as its own PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vtx1oH71AGYSX7acC6iszS)_