### PR TITLE
fix(web): auto-size task/patient table columns to stop cell overflow

### DIFF
--- a/web/components/tables/PatientList.tsx
+++ b/web/components/tables/PatientList.tsx
@@ -1162,7 +1162,7 @@ export const PatientList = forwardRef<PatientListRef, PatientListProps>(({ initi
             </div>
           )}
           <div className={clsx(listLayout === 'table' ? 'block' : 'hidden print:block')}>
-            <TableDisplay className="print-content overflow-x-auto touch-pan-x"/>
+            <TableDisplay className="print-content hw-autosize-table overflow-x-auto touch-pan-x"/>
           </div>
           {listLayout === 'card' && (
             <div className="flex flex-col gap-3 w-full print:hidden">

--- a/web/components/tables/TaskList.tsx
+++ b/web/components/tables/TaskList.tsx
@@ -1073,7 +1073,7 @@ export const TaskList = forwardRef<TaskListRef, TaskListProps>(({ tasks: initial
           `}</style>
             )}
             <div className={clsx('w-full', listLayout === 'table' ? 'block' : 'hidden print:block')}>
-              <TableDisplay className="print-content w-full overflow-x-auto touch-pan-x"/>
+              <TableDisplay className="print-content hw-autosize-table w-full overflow-x-auto touch-pan-x"/>
             </div>
             {listLayout === 'card' && (
               <div className="flex flex-col gap-3 w-full print:hidden">

--- a/web/style/index.css
+++ b/web/style/index.css
@@ -1,2 +1,3 @@
 @import "./colors.css";
 @import "./table-printing.css";
+@import "./table-autosize.css";

--- a/web/style/table-autosize.css
+++ b/web/style/table-autosize.css
@@ -1,0 +1,20 @@
+/*
+ * Content-aware sizing for the task/patient tables. Scoped to
+ * `.hw-autosize-table` so other tables (settings, properties) keep the default
+ * fixed layout from @helpwave/hightide.
+ *
+ * Switching to `table-layout: auto` lets columns grow to fit their content
+ * (long values, chips) instead of clipping/overflowing a fixed width, while the
+ * surrounding container keeps horizontal scrolling when the total exceeds the
+ * viewport. Multi-value cells (e.g. multi-select chips) already wrap, so they
+ * now flow onto additional lines instead of spilling to the right.
+ */
+table[data-name="table"].hw-autosize-table {
+  table-layout: auto;
+  width: 100% !important;
+}
+
+table[data-name="table"].hw-autosize-table [data-name="table-body-cell"],
+table[data-name="table"].hw-autosize-table [data-name="table-header-cell"] {
+  vertical-align: top;
+}


### PR DESCRIPTION
## Summary

The task and patient tables rendered with `table-layout: fixed`, so cell content wider than a column's configured size (long values, chips) spilled out to the right and chips could not flow onto a new line.

This scopes a `hw-autosize-table` class onto those two tables that switches them to `table-layout: auto`, so columns grow to fit their content while the surrounding container keeps horizontal scrolling when the total width exceeds the viewport. Multi-value cells (e.g. multi-select chips) already wrap, so they now flow onto additional lines instead of overflowing. Cells are top-aligned for tidy multi-line rows.

Other tables (settings, properties) are untouched and keep the default fixed layout.

## Changes

- `web/style/table-autosize.css` (new), imported via `web/style/index.css`.
- Add the `hw-autosize-table` class to the `TableDisplay` in `TaskList` and `PatientList`.

## Validation

- `npm run lint` (tsc --noEmit + eslint) ✅
- `npm run build` ✅ — confirmed the rule compiled into the bundle: `table[data-name=table].hw-autosize-table{table-layout:auto;width:100%!important}`

## Caveats (worth a quick visual check before merge)

- I deliberately did **not** add `overflow:hidden` to cells (it would clip the in-table edit dropdowns); auto-layout prevents the overflow instead.
- Manual column **drag-resizing** becomes approximate under `table-layout: auto` (the renderer's resize widths act as hints rather than hard widths). The actual table renderer lives in the external `@helpwave/hightide` package, so this is the cleanest fix achievable from within this repo.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vtx1oH71AGYSX7acC6iszS)_