### PR TITLE
fix(proxy): route /export/* to the backend so PDF export works

### DIFF
--- a/proxy/README.md
+++ b/proxy/README.md
@@ -34,6 +34,7 @@ docker run --rm \
 
 - `/` - Frontend application
 - `/graphql` - Backend GraphQL API
+- `/export/*` - Backend export endpoints (e.g. table PDF export)
 - `/keycloak` - Keycloak authentication service
 
 ## Production

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -25,7 +25,7 @@ http {
         listen 80;
         server_name localhost;
 
-        location ~ ^/(graphql|callback)$ {
+        location ~ ^/(graphql|callback|export/.+)$ {
             proxy_pass http://backend_upstream;
             
             proxy_set_header Host $host;


### PR DESCRIPTION
## Problem

Clicking **Print** in production failed with:

```
POST https://tasks.helpwave.de/export/table.pdf 404 (Not Found)
Error: PDF export failed with status 404
```

## Root cause

The PDF export feature (already on `main`) is correct end to end:
- Backend serves `POST /export/table.pdf` (`backend/routers/export.py`, mounted in `main.py`).
- The frontend derives the URL from the GraphQL endpoint (`…/graphql` → `…/export/table.pdf`), which is the right origin.

But the **nginx reverse proxy** only forwarded `^/(graphql|callback)$` to the backend. Every other path — including `/export/table.pdf` — fell through to the `location /` block and was sent to the **frontend**, which has no such route → 404.

Dev never hit this because the frontend talks to the backend directly (no proxy), which is why it worked locally but not in production.

## Fix

Extend the backend location match in `proxy/nginx.conf` to also cover `/export/*`:

```nginx
location ~ ^/(graphql|callback|export/.+)$ {
    proxy_pass http://backend_upstream;
    ...
}
```

`client_max_body_size 20M` is already set globally, which covers the export payload (table rows posted as text).

## Validation

- Verified the regex routes exactly the intended paths and nothing extra: `/graphql`, `/callback`, `/export/table.pdf` → backend; `/`, `/tasks`, `/export/` (no file), `/exporting`, `/graphqlx` → frontend.
- nginx isn't installed in this environment, so I couldn't run `nginx -t` against the rendered template — worth a quick `nginx -t` in the proxy image before/after deploy.

## Note

If production fronts the app with a separate ingress (e.g. a Kubernetes Ingress in an infra repo) rather than this `proxy` image, the same `/export/*` → backend rule must be added there too.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vtx1oH71AGYSX7acC6iszS)_