### PR TITLE
Fix infinite scroll loop when result set shrinks past current page

### DIFF
--- a/web/hooks/useAccumulatedPagination.test.ts
+++ b/web/hooks/useAccumulatedPagination.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { computePaginationBounds } from './useAccumulatedPagination'
+
+const PAGE_SIZE = 25
+
+describe('computePaginationBounds', () => {
+  it('reports no more pages while the total is still unknown', () => {
+    const { lastAvailablePage, hasMore } = computePaginationBounds({
+      totalCount: undefined,
+      pageSize: PAGE_SIZE,
+      pageIndex: 0,
+      accumulatedLength: 0,
+    })
+    expect(lastAvailablePage).toBeUndefined()
+    expect(hasMore).toBe(false)
+  })
+
+  it('hides "load more" when there is no content at all', () => {
+    const { hasMore } = computePaginationBounds({
+      totalCount: 0,
+      pageSize: PAGE_SIZE,
+      pageIndex: 0,
+      accumulatedLength: 0,
+    })
+    expect(hasMore).toBe(false)
+  })
+
+  it('offers more pages while earlier pages are loaded', () => {
+    expect(computePaginationBounds({
+      totalCount: 60, pageSize: PAGE_SIZE, pageIndex: 0, accumulatedLength: 25,
+    }).hasMore).toBe(true)
+    expect(computePaginationBounds({
+      totalCount: 60, pageSize: PAGE_SIZE, pageIndex: 1, accumulatedLength: 50,
+    }).hasMore).toBe(true)
+  })
+
+  it('stops once the last page has been loaded', () => {
+    const { lastAvailablePage, hasMore } = computePaginationBounds({
+      totalCount: 60, pageSize: PAGE_SIZE, pageIndex: 2, accumulatedLength: 60,
+    })
+    expect(lastAvailablePage).toBe(2)
+    expect(hasMore).toBe(false)
+  })
+
+  it('does not loop when the page index is past the end of a shrunken result set', () => {
+    // Reproduces the reported bug: total dropped to 20 (one page) while the
+    // view was paged far ahead, so every fetch returned an empty page and the
+    // sentinel kept asking for the next one.
+    const { lastAvailablePage, hasMore } = computePaginationBounds({
+      totalCount: 20,
+      pageSize: PAGE_SIZE,
+      pageIndex: 26,
+      accumulatedLength: 0,
+    })
+    expect(lastAvailablePage).toBe(0)
+    expect(hasMore).toBe(false)
+  })
+
+  it('treats a non-positive page size as an unknown bound', () => {
+    const { lastAvailablePage, hasMore } = computePaginationBounds({
+      totalCount: 20, pageSize: 0, pageIndex: 0, accumulatedLength: 0,
+    })
+    expect(lastAvailablePage).toBeUndefined()
+    expect(hasMore).toBe(true)
+  })
+})

--- a/web/hooks/useAccumulatedPagination.ts
+++ b/web/hooks/useAccumulatedPagination.ts
@@ -2,6 +2,33 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 const DEFAULT_PREFETCH_PAGES = 2
 
+/**
+ * Pure derivation of the pagination boundaries. Kept separate so the
+ * "stop at the end" logic can be unit-tested without rendering the hook.
+ *
+ * `lastAvailablePage` is the highest page index that still maps onto real data;
+ * fetching beyond it only yields empty pages (offset past the total), which is
+ * what previously kept the infinite-scroll sentinel looping forever.
+ */
+export function computePaginationBounds(options: {
+  totalCount: number | undefined,
+  pageSize: number,
+  pageIndex: number,
+  accumulatedLength: number,
+}): {
+  lastAvailablePage: number | undefined,
+  hasMore: boolean,
+} {
+  const { totalCount, pageSize, pageIndex, accumulatedLength } = options
+  const lastAvailablePage = (totalCount == null || pageSize <= 0)
+    ? undefined
+    : Math.max(0, Math.ceil(totalCount / pageSize) - 1)
+  const hasMore = totalCount != null
+    && accumulatedLength < totalCount
+    && (lastAvailablePage == null || pageIndex < lastAvailablePage)
+  return { lastAvailablePage, hasMore }
+}
+
 function reconcileFirstPage<T extends { id: string }>(prev: T[], incoming: T[]): T[] {
   // When more pages were already accumulated, keep the tail and only refresh the
   // leading page so a page-0 background refetch never shrinks the visible list.
@@ -63,12 +90,38 @@ export function useAccumulatedPagination<T extends { id: string }>(options: {
     })
   }, [pageData, pageIndex, loading])
 
-  const hasMore = totalCount != null && accumulated.length < totalCount
+  // `lastAvailablePage` is the highest page index that still maps onto real data;
+  // `hasMore` is true only when more rows are expected *and* a further page
+  // exists to fetch. Gating on the page index keeps us from offering "Load more"
+  // (or auto-loading) when the visible list is empty but a stale total still
+  // claims rows exist.
+  const { lastAvailablePage, hasMore } = useMemo(
+    () => computePaginationBounds({
+      totalCount,
+      pageSize,
+      pageIndex,
+      accumulatedLength: accumulated.length,
+    }),
+    [totalCount, pageSize, pageIndex, accumulated.length]
+  )
+
+  // Recover from an out-of-range page index. When the result set shrinks while a
+  // later page is selected (e.g. switching to a custom view with fewer rows),
+  // the active query would otherwise keep requesting empty pages past the end,
+  // never growing `accumulated`, leaving `hasMore` permanently true and spinning
+  // the infinite-scroll sentinel in a loading loop.
+  useEffect(() => {
+    if (lastAvailablePage == null) return
+    if (pageIndex > lastAvailablePage) {
+      setPageIndex(lastAvailablePage)
+    }
+  }, [lastAvailablePage, pageIndex, setPageIndex])
+
   const isFetchingMore = loading && pageIndex > 0
 
   const loadMore = useCallback(() => {
-    setPageIndex(i => i + 1)
-  }, [setPageIndex])
+    setPageIndex(i => (lastAvailablePage != null && i >= lastAvailablePage ? i : i + 1))
+  }, [setPageIndex, lastAvailablePage])
 
   const lastLoadedPage = useMemo(() => {
     if (pageSize <= 0) return pageIndex
@@ -76,14 +129,13 @@ export function useAccumulatedPagination<T extends { id: string }>(options: {
   }, [pageIndex, accumulated.length, pageSize])
 
   useEffect(() => {
-    if (!prefetchPage || loading || totalCount == null || pageSize <= 0) return
-    const lastAvailablePage = Math.ceil(totalCount / pageSize) - 1
+    if (!prefetchPage || loading || lastAvailablePage == null) return
     for (let i = 1; i <= prefetchPages; i++) {
       const target = lastLoadedPage + i
       if (target > lastAvailablePage) break
       prefetchPage(target)
     }
-  }, [prefetchPage, prefetchPages, lastLoadedPage, totalCount, pageSize, loading])
+  }, [prefetchPage, prefetchPages, lastLoadedPage, lastAvailablePage, loading])
 
   return { accumulated, loadMore, hasMore, isFetchingMore }
 }


### PR DESCRIPTION
## Summary
Fixes a bug in the accumulated pagination hook where the infinite-scroll sentinel would loop indefinitely when the result set shrinks while a later page is selected. This commonly occurs when switching between views with different numbers of results.

## Key Changes
- **Extracted `computePaginationBounds` function**: Pure logic for calculating pagination boundaries, separated from the hook for testability
  - Calculates `lastAvailablePage`: the highest page index that contains real data
  - Determines `hasMore`: whether additional pages exist to fetch
  - Handles edge cases like unknown totals, non-positive page sizes, and out-of-range indices

- **Added comprehensive unit tests**: 66 lines of test coverage for `computePaginationBounds` including:
  - Unknown total count scenarios
  - Empty result sets
  - Normal pagination flow
  - The specific bug case where page index exceeds available pages
  - Invalid page size handling

- **Fixed the infinite loop bug**: Added a `useEffect` that resets the page index to `lastAvailablePage` when the current page index exceeds available pages
  - Prevents the query from repeatedly requesting empty pages past the end
  - Stops the `hasMore` flag from remaining true indefinitely

- **Improved `loadMore` logic**: Prevents incrementing the page index beyond `lastAvailablePage`

- **Refactored prefetch logic**: Uses the computed `lastAvailablePage` instead of recalculating it, reducing duplication and improving consistency

## Implementation Details
The core issue was that when a result set shrinks (e.g., from 60 to 20 items), a page index that was valid before (e.g., page 26) becomes out of range. The old code would keep requesting page 26, get empty results, and never grow the accumulated list, leaving `hasMore` true and triggering infinite refetches. The fix detects this condition and resets to the last valid page.

https://claude.ai/code/session_01JMhYs8zdSTkkAPSyA7VFYJ