### PR TITLE
Fix printing of inline-editable table cell values

### DIFF
--- a/web/style/table-printing.css
+++ b/web/style/table-printing.css
@@ -138,6 +138,32 @@
     display: none !important;
   }
 
+  /*
+   * Inline-editable property cells render their value inside a <button>
+   * trigger (see EditablePropertyCell / InTable*EditPopUp). The generic
+   * `button { display: none }` rule below would otherwise wipe those values
+   * out of the printout, so keep buttons that live inside table cells visible
+   * and strip their interactive chrome so they read as plain text.
+   */
+  .print-content thead tr th button,
+  .print-content tbody tr td button {
+    display: inline-flex !important;
+    align-items: center;
+    width: auto !important;
+    min-width: 0 !important;
+    max-width: 100% !important;
+    height: auto !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    border: none !important;
+    border-radius: 0 !important;
+    background: transparent !important;
+    color: black !important;
+    box-shadow: none !important;
+    font: inherit !important;
+    text-align: left !important;
+  }
+
   .print-button,
   button {
     display: none !important;


### PR DESCRIPTION
## Summary
This change ensures that inline-editable property cells display their values correctly when printing, while maintaining the print stylesheet's general rule of hiding buttons.

## Key Changes
- Added CSS rules to keep buttons inside table header and body cells visible during printing
- Stripped all interactive styling (borders, backgrounds, shadows, padding, margins) from these buttons so they render as plain text
- Preserved button content and text alignment to maintain readability in printed output

## Implementation Details
The fix targets buttons specifically within `.print-content thead tr th` and `.print-content tbody tr td` selectors, overriding the generic `button { display: none }` rule that would otherwise hide the editable cell values. The buttons are styled with `display: inline-flex` and have all visual chrome removed (background, border, box-shadow, etc.) while inheriting the font from the parent element, making them appear as regular text in the printed document.

https://claude.ai/code/session_01Pz8wqwQhDmEKGpHayg8CPs