### PR TITLE
fix(web): add print margins and scale wide tables to fit the page

### DIFF
--- a/web/style/table-printing.css
+++ b/web/style/table-printing.css
@@ -1,7 +1,10 @@
 @media print {
   @page {
     size: A4 landscape;
-    margin: 0;
+    /* Give the printout breathing room on every edge. The table below is
+       constrained to the resulting printable width, so the margins are added
+       without clipping any columns. */
+    margin: 1cm;
   }
 
   * {
@@ -65,7 +68,10 @@
     @apply !text-sm;
     page-break-inside: auto;
 
-    table-layout: auto !important;
+    /* Fixed layout makes every column share the printable width evenly instead
+       of growing to fit its content, so a wide table scales down to the page
+       (with its new margins) rather than overflowing and getting clipped. */
+    table-layout: fixed !important;
     border-collapse: collapse;
     border: 1px solid black;
   }
@@ -75,11 +81,11 @@
     break-after: avoid;
   }
 
-  /* TODO consider this, if all columns should have the same width
+  /* Drop any per-column widths the on-screen auto-size feature applied so the
+     fixed layout can share the printable width evenly across all columns. */
   .print-content colgroup col {
-      width: auto !important;
+    width: auto !important;
   }
-  */
 
   .print-content thead tr th,
   .print-content tbody tr td,
@@ -91,6 +97,11 @@
     @apply !text-sm;
     overflow: visible !important;
     white-space: pre-wrap !important;
+    /* With fixed table layout columns can get narrow, so allow long values to
+       wrap (and break mid-word as a last resort) instead of spilling past the
+       column edge and being clipped at the page margin. */
+    word-break: break-word !important;
+    overflow-wrap: anywhere !important;
   }
 
   .print-content thead tr th {


### PR DESCRIPTION
## What

Improves the native browser print view (Ctrl+P) for the task/patient tables.

Previously the print stylesheet used a zero-margin `@page` together with an
auto-layout table, so:
- the table printed edge-to-edge with no margins, and
- wide tables overflowed the sheet and were **clipped on the right**.

## Changes (`web/style/table-printing.css`, print media only)

- **Add a `1cm` page margin** on every edge for breathing room.
- **Switch the printed table to `table-layout: fixed`** with even, page-width
  columns, and neutralize the on-screen auto-size per-column widths
  (`.print-content colgroup col { width: auto }`). This makes a wide table
  *scale down* to the printable area instead of overflowing.
- **Let long cell values wrap** (`word-break: break-word` /
  `overflow-wrap: anywhere`) so content reflows within its (now narrower)
  column rather than being cut at the page margin.

Net effect: margins are added and the whole table scales to fit the page
without cutting content.

## Notes

Print-media CSS only — no runtime/TS behavior changes. Builds on the
already-merged #237 (inline-editable property cells now print).

https://claude.ai/code/session_01Pz8wqwQhDmEKGpHayg8CPs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pz8wqwQhDmEKGpHayg8CPs)_