### PR TITLE
fix(web): enable vertical touch scrolling on tables

### DIFF
--- a/web/components/tables/PatientList.tsx
+++ b/web/components/tables/PatientList.tsx
@@ -1156,7 +1156,7 @@ export const PatientList = forwardRef<PatientListRef, PatientListProps>(({ initi
             </div>
           )}
           <div className={clsx(listLayout === 'table' ? 'block' : 'hidden print:block')}>
-            <TableDisplay className="print-content hw-autosize-table overflow-x-auto touch-pan-x"/>
+            <TableDisplay className="print-content hw-autosize-table overflow-x-auto hw-touch-scroll"/>
           </div>
           {listLayout === 'card' && (
             <div className="flex flex-col gap-3 w-full print:hidden">

--- a/web/components/tables/TaskList.tsx
+++ b/web/components/tables/TaskList.tsx
@@ -1075,7 +1075,7 @@ export const TaskList = forwardRef<TaskListRef, TaskListProps>(({ tasks: initial
           `}</style>
             )}
             <div className={clsx('w-full', listLayout === 'table' ? 'block' : 'hidden print:block')}>
-              <TableDisplay className="print-content hw-autosize-table w-full overflow-x-auto touch-pan-x"/>
+              <TableDisplay className="print-content hw-autosize-table w-full overflow-x-auto hw-touch-scroll"/>
             </div>
             {listLayout === 'card' && (
               <div className="flex flex-col gap-3 w-full print:hidden">

--- a/web/globals.css
+++ b/web/globals.css
@@ -15,7 +15,15 @@
 }
 
 @layer utilities {
-  .touch-pan-x {
+  /*
+   * Enables momentum scrolling for overflow containers (e.g. horizontally
+   * scrollable tables) without constraining `touch-action`. We intentionally
+   * avoid Tailwind's `touch-pan-x` utility here: that sets
+   * `touch-action: pan-x`, which makes the browser treat the element as
+   * horizontal-only and swallows vertical scroll gestures, breaking vertical
+   * touch scrolling of the surrounding page on phones and tablets.
+   */
+  .hw-touch-scroll {
     -webkit-overflow-scrolling: touch;
   }
 }


### PR DESCRIPTION
## Problem

On touch devices (Android phones, iOS phones, and iOS tablets) the task and patient tables could only be scrolled **horizontally**. Vertical touch scrolling over the table area was completely broken — the surrounding page would not scroll when the user dragged vertically with a finger on top of a table.

## Root cause

The table containers in `TaskList.tsx` and `PatientList.tsx` used the class `touch-pan-x`:

```tsx
<TableDisplay className="... overflow-x-auto touch-pan-x"/>
```

That class name collides with **Tailwind v4's built-in `touch-pan-x` utility**, which emits `touch-action: pan-x`. On touch devices this tells the browser the element only handles horizontal panning, so vertical scroll gestures starting on the table are swallowed and never propagate to the parent `overflow-y-auto` scroll container.

The custom utility in `globals.css` was only ever intended to add momentum scrolling:

```css
.touch-pan-x { -webkit-overflow-scrolling: touch; }
```

…but because of the colliding name it inherited the harmful `touch-action: pan-x` from Tailwind.

## Fix

Rename the custom utility to `hw-touch-scroll` (no collision with any Tailwind utility). It still enables momentum scrolling, while `touch-action` falls back to its default `auto` — so the table scrolls horizontally **and** vertical drags scroll the page as expected.

- `globals.css`: rename `.touch-pan-x` → `.hw-touch-scroll`, with an explanatory comment about why Tailwind's `touch-pan-x` must be avoided.
- `TaskList.tsx` / `PatientList.tsx`: use `hw-touch-scroll` instead of `touch-pan-x`.

No behavior change on desktop; horizontal table scrolling is preserved.

https://claude.ai/code/session_01D3JcefZKvXmtdbmeFNQXSu

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3JcefZKvXmtdbmeFNQXSu)_