### PR TITLE
feat(web): auto-load list pages on scroll with a reliable "Load more" fallback

### DIFF
--- a/web/components/common/InfiniteScrollSentinel.tsx
+++ b/web/components/common/InfiniteScrollSentinel.tsx
@@ -1,20 +1,24 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { findScrollableAncestor } from '@/utils/scrollableAncestor'
 
 type InfiniteScrollSentinelProps = {
   onLoadMore: () => void,
   hasMore: boolean,
   isFetchingMore: boolean,
-  /** Distance from the viewport at which loading kicks in. Defaults to 800px. */
+  /** Distance from the scroll container edge at which loading kicks in. Defaults to 800px. */
   rootMargin?: string,
   className?: string,
 }
 
 /**
- * Invisible marker that triggers `onLoadMore` as it approaches the viewport.
- * The generous root margin loads the next window before the user reaches the
- * bottom, which keeps scrolling smooth on touch devices. Intersection state is
- * tracked so loading continues even when the marker stays in view after a page
- * resolves.
+ * Invisible marker that triggers `onLoadMore` as it approaches the bottom of the
+ * scroll container. The observer is rooted at the nearest scrollable ancestor
+ * (falling back to the viewport) so the generous root margin actually loads the
+ * next window *before* the user reaches the bottom — when the target is rooted at
+ * the viewport instead, an intervening `overflow-y-auto` container clips the
+ * sentinel and the margin is ignored. Intersection state is tracked so loading
+ * continues even when the marker stays in view after a page resolves (e.g. when
+ * a page is shorter than the viewport).
  */
 export function InfiniteScrollSentinel({
   onLoadMore,
@@ -23,22 +27,25 @@ export function InfiniteScrollSentinel({
   rootMargin = '800px',
   className,
 }: InfiniteScrollSentinelProps) {
-  const ref = useRef<HTMLDivElement | null>(null)
+  // A callback ref (state) re-runs the observer effect whenever the sentinel
+  // mounts or unmounts. `hasMore` toggling false→true remounts the node with a
+  // fresh element, and this keeps the observer attached to the live node instead
+  // of a detached one.
+  const [node, setNode] = useState<HTMLDivElement | null>(null)
   const [isIntersecting, setIsIntersecting] = useState(false)
 
   useEffect(() => {
-    const node = ref.current
     if (!node || typeof IntersectionObserver === 'undefined') return
     const observer = new IntersectionObserver(
       (entries) => {
         const entry = entries[0]
         if (entry) setIsIntersecting(entry.isIntersecting)
       },
-      { rootMargin }
+      { root: findScrollableAncestor(node), rootMargin }
     )
     observer.observe(node)
     return () => observer.disconnect()
-  }, [rootMargin])
+  }, [node, rootMargin])
 
   const onLoadMoreRef = useRef(onLoadMore)
   onLoadMoreRef.current = onLoadMore
@@ -49,7 +56,9 @@ export function InfiniteScrollSentinel({
     }
   }, [isIntersecting, hasMore, isFetchingMore])
 
+  const setRef = useCallback((el: HTMLDivElement | null) => setNode(el), [])
+
   if (!hasMore) return null
 
-  return <div ref={ref} aria-hidden className={className} />
+  return <div ref={setRef} aria-hidden className={className} />
 }

--- a/web/utils/scrollableAncestor.test.ts
+++ b/web/utils/scrollableAncestor.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { isScrollableOverflowY } from './scrollableAncestor'
+
+describe('isScrollableOverflowY', () => {
+  it('treats auto, scroll and overlay as scrollable', () => {
+    expect(isScrollableOverflowY('auto')).toBe(true)
+    expect(isScrollableOverflowY('scroll')).toBe(true)
+    expect(isScrollableOverflowY('overlay')).toBe(true)
+  })
+
+  it('treats visible, hidden and clip as non-scrollable', () => {
+    expect(isScrollableOverflowY('visible')).toBe(false)
+    expect(isScrollableOverflowY('hidden')).toBe(false)
+    expect(isScrollableOverflowY('clip')).toBe(false)
+    expect(isScrollableOverflowY('')).toBe(false)
+  })
+})

--- a/web/utils/scrollableAncestor.ts
+++ b/web/utils/scrollableAncestor.ts
@@ -1,0 +1,34 @@
+/**
+ * Helpers for locating the scroll container an element actually lives in.
+ *
+ * Infinite-scroll relies on an IntersectionObserver. When `root` is left as the
+ * viewport but the content is rendered inside a nested `overflow-y-auto`
+ * container (as the app shell does in `Page`), intermediate scroll containers
+ * clip the observed target, so a generous `rootMargin` lookahead is silently
+ * ignored — the sentinel only intersects once it reaches the very bottom.
+ * Observing against the real scroll container restores the "load before the
+ * bottom is reached" behaviour.
+ */
+
+/** A computed `overflow-y` value that lets the element scroll its content. */
+export function isScrollableOverflowY(overflowY: string): boolean {
+  return overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay'
+}
+
+/**
+ * Walks up from `node` and returns the nearest ancestor that scrolls vertically.
+ * Stops at (and ignores) the document root, where `root: null` (the viewport) is
+ * already the correct IntersectionObserver root. Returns `null` when no nested
+ * scroll container exists, which the caller should treat as "use the viewport".
+ */
+export function findScrollableAncestor(node: Element | null): HTMLElement | null {
+  if (typeof window === 'undefined') return null
+  let current = node?.parentElement ?? null
+  while (current && current !== document.body && current !== document.documentElement) {
+    if (isScrollableOverflowY(window.getComputedStyle(current).overflowY)) {
+      return current
+    }
+    current = current.parentElement
+  }
+  return null
+}


### PR DESCRIPTION
## What & why

The task and patient lists should pull the next page automatically as you scroll toward the bottom (when a next page exists), and otherwise offer a **Load more** button when not already loading — in both card and table views, including on mobile.

The infinite-scroll machinery already landed on this branch (`useAccumulatedPagination` + `InfiniteScrollSentinel`, with the end-of-results loop guard). This PR makes the auto-load actually behave as intended by fixing where the sentinel observes from.

## The fix

`InfiniteScrollSentinel` ran its `IntersectionObserver` against the viewport (`root: null`). But the lists render inside the app shell's scroll container (`Page` → `div.overflow-y-auto`). An intervening scroll container **clips the observed target**, so the generous `800px` `rootMargin` lookahead was silently ignored — the next page only loaded once the user hit the very bottom, instead of as the bottom came into view.

Changes:
- Resolve the **nearest scrollable ancestor** and use it as the observer `root`, so the lookahead margin works (loads before you reach the bottom). Falls back to the viewport when there is no nested scroll container. New helper `utils/scrollableAncestor.ts`.
- Switch the sentinel to a **callback ref** so the observer re-attaches when the node remounts after `hasMore` toggles `false → true`. Previously the setup effect only depended on `rootMargin` and could be left observing a detached node (or never attach if the list started empty).
- Unit test for the pure overflow predicate (`utils/scrollableAncestor.test.ts`).

## Behaviour after this change

- **Auto-load on scroll** triggers ~800px before the scroll container's bottom edge, in card and table views, on desktop and mobile.
- **Load more** button still shows when there is a next page and a fetch isn't already in flight; a spinner shows while fetching.
- No auto-load / no button when there is no next page (existing `useAccumulatedPagination` end-of-results gating is unchanged).
- Short pages that don't fill the container keep loading until the viewport is filled or the data is exhausted.

## Validation

- `npm run lint` (tsc + eslint) — clean
- `npm run test` — 21 passing (added `scrollableAncestor` test)
- `npm run check-translations` — clean (`loadMore` key present in all locales)

> Note: this branch is ahead of `main` by the recent web list/table commits (`#230`–`#240`); the headline change here is the scroll-container observer fix described above.

https://claude.ai/code/session_01W5tHwmE9ZTnCa7HFzqid2A

---
_Generated by [Claude Code](https://claude.ai/code/session_01W5tHwmE9ZTnCa7HFzqid2A)_