### PR TITLE
Reload entities after mutations to reflect server-computed fields

### DIFF
--- a/web/components/tables/PatientList.tsx
+++ b/web/components/tables/PatientList.tsx
@@ -1170,23 +1170,25 @@ export const PatientList = forwardRef<PatientListRef, PatientListProps>(({ initi
               ))}
             </div>
           )}
-          {!embedded && !derivedVirtualMode && (
+          {!embedded && !derivedVirtualMode && stableTotalCount != null && hasMore && (
             <>
               <InfiniteScrollSentinel
                 onLoadMore={loadMore}
-                hasMore={stableTotalCount != null && hasMore}
+                hasMore={hasMore}
                 isFetchingMore={isFetchingMore}
               />
-              {isFetchingMore && (
-                <div className="flex justify-center py-2 print:hidden" aria-busy>
-                  <Loader2 className="size-5 animate-spin text-description" />
-                </div>
-              )}
-              {stableTotalCount != null && hasMore && !isFetchingMore && (
-                <Button color="neutral" className="mt-2 w-full sm:w-auto self-center print:hidden" onClick={loadMore}>
-                  {translation('loadMore')}
-                </Button>
-              )}
+              {/* Always render the manual loader at the bottom: infinite-scroll
+                  auto-loading is unreliable on mobile, so the button is the
+                  dependable fallback for loading the next page by hand. */}
+              <Button
+                color="neutral"
+                className="mt-2 w-full sm:w-auto self-center print:hidden"
+                onClick={loadMore}
+                disabled={isFetchingMore}
+              >
+                {isFetchingMore && <Loader2 className="size-5 animate-spin" />}
+                {translation(isFetchingMore ? 'loading' : 'loadMore')}
+              </Button>
             </>
           )}
         </div>

--- a/web/components/tables/TaskList.tsx
+++ b/web/components/tables/TaskList.tsx
@@ -1091,23 +1091,25 @@ export const TaskList = forwardRef<TaskListRef, TaskListProps>(({ tasks: initial
                 ))}
               </div>
             )}
-            {!embedded && (
+            {!embedded && effectiveHasMore && (
               <>
                 <InfiniteScrollSentinel
                   onLoadMore={handleLoadMore}
                   hasMore={effectiveHasMore}
                   isFetchingMore={isFetchingMore}
                 />
-                {isFetchingMore && (
-                  <div className="flex justify-center py-2 print:hidden" aria-busy>
-                    <Loader2 className="size-5 animate-spin text-description" />
-                  </div>
-                )}
-                {effectiveHasMore && !isFetchingMore && (
-                  <Button color="neutral" className="mt-2 w-full sm:w-auto self-center print:hidden" onClick={handleLoadMore}>
-                    {translation('loadMore')}
-                  </Button>
-                )}
+                {/* Always render the manual loader at the bottom: infinite-scroll
+                    auto-loading is unreliable on mobile, so the button is the
+                    dependable fallback for loading the next page by hand. */}
+                <Button
+                  color="neutral"
+                  className="mt-2 w-full sm:w-auto self-center print:hidden"
+                  onClick={handleLoadMore}
+                  disabled={isFetchingMore}
+                >
+                  {isFetchingMore && <Loader2 className="size-5 animate-spin" />}
+                  {translation(isFetchingMore ? 'loading' : 'loadMore')}
+                </Button>
               </>
             )}
           </div>

--- a/web/data/mutations/runner.ts
+++ b/web/data/mutations/runner.ts
@@ -8,7 +8,8 @@ import type { MutateOptimisticOptions, OptimisticPatch } from './types'
 import { schedulePersistCache } from '../cache/persist'
 import {
   clearEntityMutated,
-  markEntityMutated
+  markEntityMutated,
+  reloadEntityAfterMutation
 } from '../subscriptions/handler'
 import * as storage from '../storage/indexed-db'
 
@@ -91,6 +92,12 @@ export async function mutateOptimistic<TData, TVariables>(
     }
     onSuccess?.(result.data, variables)
     schedulePersistCache(cache)
+    // Reload the mutated entity from the server so server-computed fields are
+    // reflected after our optimistic write. Fire-and-forget: the optimistic UI
+    // is already in place and the row dims via the refreshing gate meanwhile.
+    if (typeof vars?.['id'] === 'string') {
+      void reloadEntityAfterMutation(client, entityType, vars['id'])
+    }
     return result.data
   } catch (error) {
     for (const patch of patches) {

--- a/web/data/subscriptions/handler.test.ts
+++ b/web/data/subscriptions/handler.test.ts
@@ -1,10 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ApolloClient } from '@apollo/client/core'
 import {
   clearEntityMutated,
   markEntityMutated,
+  reloadEntityAfterMutation,
   shouldSkipMergePatient,
   shouldSkipMergeTask
 } from './handler'
+import { getRefreshingPatientIds } from './refreshingEntities'
 
 const noPending = () => false
 
@@ -70,6 +73,46 @@ describe('echo detection', () => {
     expect(
       shouldSkipMergePatient('patient-1', {}, { conflictStrategy: 'defer', getPendingForEntity: noPending })
     ).toBe(false)
+  })
+})
+
+describe('reloadEntityAfterMutation', () => {
+  it('reloads the entity, refetches active lists, and toggles the refreshing gate', async () => {
+    let gatedDuringRefetch = false
+    const client = {
+      query: vi.fn().mockResolvedValue({
+        data: { patient: { __typename: 'PatientType', id: 'patient-1', updateDate: '2026-01-02T00:00:00Z' } },
+      }),
+      cache: {
+        readQuery: vi.fn().mockReturnValue({ patient: { updateDate: '2026-01-01T00:00:00Z' } }),
+        writeQuery: vi.fn(),
+      },
+      refetchQueries: vi.fn().mockImplementation(() => {
+        // Capture the gate state while the reload is still in flight.
+        gatedDuringRefetch = getRefreshingPatientIds().has('patient-1')
+        return Promise.resolve([])
+      }),
+    } as unknown as ApolloClient
+
+    await reloadEntityAfterMutation(client, 'Patient', 'patient-1')
+
+    expect(client.query).toHaveBeenCalled()
+    expect(client.refetchQueries).toHaveBeenCalled()
+    expect(gatedDuringRefetch).toBe(true)
+    // The gate is released once the reload settles.
+    expect(getRefreshingPatientIds().has('patient-1')).toBe(false)
+  })
+
+  it('releases the refreshing gate even when the reload fails', async () => {
+    const client = {
+      query: vi.fn().mockRejectedValue(new Error('network down')),
+      cache: { readQuery: vi.fn(), writeQuery: vi.fn() },
+      refetchQueries: vi.fn(),
+    } as unknown as ApolloClient
+
+    await reloadEntityAfterMutation(client, 'Patient', 'patient-1')
+
+    expect(getRefreshingPatientIds().has('patient-1')).toBe(false)
   })
 })
 

--- a/web/data/subscriptions/handler.ts
+++ b/web/data/subscriptions/handler.ts
@@ -1,7 +1,13 @@
 import type { ApolloClient } from '@apollo/client/core'
-import { GetTaskDocument, GetPatientDocument } from '@/api/gql/generated'
+import { GetTaskDocument, GetPatientDocument, GetTasksDocument, GetPatientsDocument } from '@/api/gql/generated'
 import { getParsedDocument } from '../hooks/queryHelpers'
 import { hasPendingMutationForEntity } from '../mutations/queue'
+import {
+  addRefreshingTask,
+  removeRefreshingTask,
+  addRefreshingPatient,
+  removeRefreshingPatient
+} from './refreshingEntities'
 
 export type SubscriptionPayload = {
   taskId?: string,
@@ -180,4 +186,62 @@ export function mergeSubscriptionIntoCache(
     return mergePatientUpdatedIntoCache(client, payload.patientId, payload, options)
   }
   return Promise.resolve()
+}
+
+/**
+ * Reload an entity from the server after we mutated it ourselves.
+ *
+ * Our optimistic update only writes the fields we know about, and the
+ * subscription echo for our own change is intentionally suppressed (see
+ * `isLikelyEcho`), so without this the row would keep showing the optimistic
+ * value and never pick up server-computed fields (e.g. the derived full `name`,
+ * `updateDate`, or normalized property values). Refetching the active queries
+ * for the entity reconciles the visible list/detail with the server while the
+ * row is dimmed by the refreshing gate, mirroring the realtime update path.
+ *
+ * Must be called *after* `clearEntityMutated`, otherwise the echo guard inside
+ * the merge helpers would short-circuit the reload.
+ */
+export async function reloadEntityAfterMutation(
+  client: ApolloClient,
+  entityType: 'Task' | 'Patient',
+  entityId: string
+): Promise<void> {
+  if (entityType === 'Task') {
+    addRefreshingTask(entityId)
+    try {
+      await mergeTaskUpdatedIntoCache(
+        client,
+        entityId,
+        { taskId: entityId },
+        { conflictStrategy: 'server-wins' }
+      )
+      await client.refetchQueries({
+        include: [getParsedDocument(GetTasksDocument), getParsedDocument(GetPatientsDocument)],
+      })
+    } catch {
+      // A failed reload must never surface as a mutation failure; the optimistic
+      // value stays until the next refetch or subscription event.
+    } finally {
+      removeRefreshingTask(entityId)
+    }
+    return
+  }
+
+  addRefreshingPatient(entityId)
+  try {
+    await mergePatientUpdatedIntoCache(
+      client,
+      entityId,
+      { patientId: entityId },
+      { conflictStrategy: 'server-wins' }
+    )
+    await client.refetchQueries({
+      include: [getParsedDocument(GetPatientsDocument), getParsedDocument(GetTasksDocument)],
+    })
+  } catch {
+    // See above: keep the optimistic value rather than failing the mutation.
+  } finally {
+    removeRefreshingPatient(entityId)
+  }
 }

--- a/web/hooks/useAccumulatedPagination.ts
+++ b/web/hooks/useAccumulatedPagination.ts
@@ -81,10 +81,15 @@ export function useAccumulatedPagination<T extends { id: string }>(options: {
       return
     }
     setAccumulated(prev => {
-      const ids = new Set(prev.map(x => x.id))
-      const next = [...prev]
+      // Refresh already-accumulated rows in place with the freshly fetched copy
+      // (so a row reloaded after an edit reflects the server value instead of the
+      // stale object captured when the page was first appended), then append any
+      // rows we have not seen yet.
+      const incomingById = new Map(pageData.map(item => [item.id, item]))
+      const existingIds = new Set(prev.map(item => item.id))
+      const next = prev.map(item => incomingById.get(item.id) ?? item)
       for (const item of pageData) {
-        if (!ids.has(item.id)) next.push(item)
+        if (!existingIds.has(item.id)) next.push(item)
       }
       return next
     })


### PR DESCRIPTION
## Summary
This PR implements entity reloading after mutations to ensure server-computed fields (like derived names, update dates, and normalized values) are reflected in the UI. Previously, optimistic updates would persist stale values since subscription echoes for own changes are intentionally suppressed.

## Key Changes

- **New `reloadEntityAfterMutation` function** in `handler.ts`: Reloads an entity from the server after a local mutation, refetches active queries, and uses a "refreshing gate" to dim the row during the reload. Gracefully handles failures by keeping the optimistic value.

- **Refreshing gate integration**: Uses `addRefreshingTask`/`addRefreshingPatient` and `removeRefreshingTask`/`removeRefreshingPatient` to track entities being reloaded, allowing the UI to show a loading state.

- **Automatic reload trigger** in `runner.ts`: The `mutateOptimistic` function now automatically calls `reloadEntityAfterMutation` after successful mutations (fire-and-forget pattern).

- **Improved pagination handling** in `useAccumulatedPagination.ts`: When appending new pages, already-accumulated rows are refreshed in place with freshly fetched data, ensuring edited rows reflect server values instead of stale cached objects.

- **Simplified pagination UI** in `PatientList.tsx` and `TaskList.tsx`: Consolidated the loading state UI into a single always-visible "Load More" button that shows a spinner when fetching. This provides a more reliable fallback for mobile users where infinite-scroll auto-loading is unreliable.

## Implementation Details

- The reload must occur *after* `clearEntityMutated` to avoid the echo guard short-circuiting the reload
- Failed reloads are silently caught to prevent mutation failures; the optimistic value persists until the next refetch or subscription event
- The refreshing gate is always released in a `finally` block, even if the reload fails
- Comprehensive test coverage added for the new reload functionality, including success and failure scenarios

https://claude.ai/code/session_0142CotRhxgLvEUEZGTWQTTz