### PR TITLE
chore: remove comments and improve readability across web and backend

### DIFF
--- a/backend/database/models/saved_view.py
+++ b/backend/database/models/saved_view.py
@@ -26,9 +26,7 @@ class SavedView(Base):
         default=lambda: str(uuid.uuid4()),
     )
     name: Mapped[str] = mapped_column(String, nullable=False)
-    base_entity_type: Mapped[str] = mapped_column(
-        String, nullable=False
-    )  # 'task' | 'patient'
+    base_entity_type: Mapped[str] = mapped_column(String, nullable=False)
     filter_definition: Mapped[str] = mapped_column(Text, nullable=False, default="{}")
     sort_definition: Mapped[str] = mapped_column(Text, nullable=False, default="{}")
     parameters: Mapped[str] = mapped_column(Text, nullable=False, default="{}")
@@ -38,9 +36,7 @@ class SavedView(Base):
     owner_user_id: Mapped[str] = mapped_column(
         String, ForeignKey("users.id"), nullable=False
     )
-    visibility: Mapped[str] = mapped_column(
-        String, nullable=False, default="private"
-    )  # 'private' | 'link_shared'
+    visibility: Mapped[str] = mapped_column(String, nullable=False, default="private")
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/backend/tests/unit/test_datetime_service.py
+++ b/backend/tests/unit/test_datetime_service.py
@@ -1,0 +1,29 @@
+from datetime import datetime, timedelta, timezone
+
+from api.services.datetime import normalize_datetime_to_utc
+
+
+def test_none_returns_none() -> None:
+    assert normalize_datetime_to_utc(None) is None
+
+
+def test_naive_datetime_is_returned_unchanged() -> None:
+    naive = datetime(2026, 1, 1, 12, 0, 0)
+    result = normalize_datetime_to_utc(naive)
+    assert result == naive
+    assert result.tzinfo is None
+
+
+def test_utc_aware_datetime_is_stripped_to_naive() -> None:
+    aware = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    result = normalize_datetime_to_utc(aware)
+    assert result == datetime(2026, 1, 1, 12, 0, 0)
+    assert result.tzinfo is None
+
+
+def test_offset_datetime_is_converted_to_utc() -> None:
+    plus_two = timezone(timedelta(hours=2))
+    aware = datetime(2026, 1, 1, 12, 0, 0, tzinfo=plus_two)
+    result = normalize_datetime_to_utc(aware)
+    assert result == datetime(2026, 1, 1, 10, 0, 0)
+    assert result.tzinfo is None

--- a/backend/tests/unit/test_task_graph.py
+++ b/backend/tests/unit/test_task_graph.py
@@ -1,7 +1,12 @@
+from dataclasses import dataclass
+
 import pytest
 from graphql import GraphQLError
 
-from api.services.task_graph import validate_task_graph_dict
+from api.services.task_graph import (
+    graph_dict_from_preset_inputs,
+    validate_task_graph_dict,
+)
 
 
 def test_validate_empty_nodes_raises() -> None:
@@ -46,3 +51,96 @@ def test_validate_linear_ok() -> None:
             "edges": [{"from": "a", "to": "b"}],
         },
     )
+
+
+def test_validate_duplicate_node_id_raises() -> None:
+    with pytest.raises(GraphQLError, match="Duplicate node id"):
+        validate_task_graph_dict(
+            {
+                "nodes": [
+                    {"id": "a", "title": "A"},
+                    {"id": "a", "title": "B"},
+                ],
+                "edges": [],
+            },
+        )
+
+
+def test_validate_node_without_title_raises() -> None:
+    with pytest.raises(GraphQLError, match="non-empty title"):
+        validate_task_graph_dict(
+            {"nodes": [{"id": "a", "title": ""}], "edges": []},
+        )
+
+
+def test_validate_edge_referencing_unknown_node_raises() -> None:
+    with pytest.raises(GraphQLError, match="unknown node id"):
+        validate_task_graph_dict(
+            {
+                "nodes": [{"id": "a", "title": "A"}],
+                "edges": [{"from": "a", "to": "missing"}],
+            },
+        )
+
+
+def test_validate_edges_must_be_a_list() -> None:
+    with pytest.raises(GraphQLError, match="edges must be a list"):
+        validate_task_graph_dict(
+            {"nodes": [{"id": "a", "title": "A"}], "edges": {}},
+        )
+
+
+@dataclass
+class _PresetNode:
+    node_id: str
+    title: str
+    description: str | None = None
+    priority: object | None = None
+    estimated_time: int | None = None
+
+
+@dataclass
+class _PresetEdge:
+    from_node_id: str
+    to_node_id: str
+
+
+class _Priority:
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+
+def test_graph_dict_from_preset_inputs_maps_nodes_and_edges() -> None:
+    nodes = [
+        _PresetNode("a", "A", description="first", priority=_Priority("P1"), estimated_time=30),
+        _PresetNode("b", "B"),
+    ]
+    edges = [_PresetEdge("a", "b")]
+
+    graph = graph_dict_from_preset_inputs(nodes, edges)
+
+    assert graph == {
+        "nodes": [
+            {
+                "id": "a",
+                "title": "A",
+                "description": "first",
+                "priority": "P1",
+                "estimated_time": 30,
+            },
+            {
+                "id": "b",
+                "title": "B",
+                "description": None,
+                "priority": None,
+                "estimated_time": None,
+            },
+        ],
+        "edges": [{"from": "a", "to": "b"}],
+    }
+
+
+def test_graph_dict_from_preset_inputs_result_passes_validation() -> None:
+    nodes = [_PresetNode("a", "A"), _PresetNode("b", "B")]
+    edges = [_PresetEdge("a", "b")]
+    validate_task_graph_dict(graph_dict_from_preset_inputs(nodes, edges))

--- a/backend/tests/unit/test_validation_service.py
+++ b/backend/tests/unit/test_validation_service.py
@@ -1,0 +1,39 @@
+import pytest
+
+from api.services.validation import LocationValidator
+
+
+class _Location:
+    def __init__(self, kind: str) -> None:
+        self.kind = kind
+
+
+def test_validate_kind_accepts_matching_kind_case_insensitively() -> None:
+    LocationValidator.validate_kind(_Location("ward"), "WARD", "position")
+
+
+def test_validate_kind_rejects_mismatching_kind() -> None:
+    with pytest.raises(Exception, match="must be a location of kind WARD"):
+        LocationValidator.validate_kind(_Location("ROOM"), "WARD", "position")
+
+
+@pytest.mark.parametrize(
+    "kind", ["HOSPITAL", "PRACTICE", "CLINIC", "WARD", "BED", "ROOM"]
+)
+def test_validate_position_kind_accepts_allowed_kinds(kind: str) -> None:
+    LocationValidator.validate_position_kind(_Location(kind.lower()), "position")
+
+
+def test_validate_position_kind_rejects_team() -> None:
+    with pytest.raises(Exception, match="must be a location of kind"):
+        LocationValidator.validate_position_kind(_Location("TEAM"), "position")
+
+
+@pytest.mark.parametrize("kind", ["CLINIC", "TEAM", "PRACTICE", "HOSPITAL"])
+def test_validate_team_kind_accepts_allowed_kinds(kind: str) -> None:
+    LocationValidator.validate_team_kind(_Location(kind), "team")
+
+
+def test_validate_team_kind_rejects_bed() -> None:
+    with pytest.raises(Exception, match="must be a location of kind"):
+        LocationValidator.validate_team_kind(_Location("BED"), "team")

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+
+const baseURL = process.env.E2E_BASE_URL || 'http://localhost:3000';
+
+test.describe('Smoke', () => {
+  test('should render the document shell on the landing page', async ({ page, baseURL: configBaseURL }) => {
+    const url = configBaseURL || baseURL;
+    await page.goto(url);
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('html')).toHaveCount(1);
+    await expect(page.locator('body')).toBeVisible();
+  });
+
+  test('should render on a mobile viewport', async ({ page, baseURL: configBaseURL }) => {
+    const url = configBaseURL || baseURL;
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto(url);
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.locator('body')).toBeVisible();
+  });
+
+  test('should expose core entity routes without crashing', async ({ page, baseURL: configBaseURL }) => {
+    const baseUrl = configBaseURL || baseURL;
+
+    for (const path of ['/tasks', '/patients']) {
+      const response = await page.goto(`${baseUrl}${path}`);
+      await page.waitForLoadState('networkidle');
+
+      if (response) {
+        expect(response.status()).toBeLessThan(500);
+      }
+      await expect(page.locator('body')).toBeVisible();
+    }
+  });
+});

--- a/web/components/common/InfiniteScrollSentinel.tsx
+++ b/web/components/common/InfiniteScrollSentinel.tsx
@@ -5,21 +5,10 @@ type InfiniteScrollSentinelProps = {
   onLoadMore: () => void,
   hasMore: boolean,
   isFetchingMore: boolean,
-  /** Distance from the scroll container edge at which loading kicks in. Defaults to 800px. */
   rootMargin?: string,
   className?: string,
 }
 
-/**
- * Invisible marker that triggers `onLoadMore` as it approaches the bottom of the
- * scroll container. The observer is rooted at the nearest scrollable ancestor
- * (falling back to the viewport) so the generous root margin actually loads the
- * next window *before* the user reaches the bottom — when the target is rooted at
- * the viewport instead, an intervening `overflow-y-auto` container clips the
- * sentinel and the margin is ignored. Intersection state is tracked so loading
- * continues even when the marker stays in view after a page resolves (e.g. when
- * a page is shorter than the viewport).
- */
 export function InfiniteScrollSentinel({
   onLoadMore,
   hasMore,
@@ -27,10 +16,6 @@ export function InfiniteScrollSentinel({
   rootMargin = '800px',
   className,
 }: InfiniteScrollSentinelProps) {
-  // A callback ref (state) re-runs the observer effect whenever the sentinel
-  // mounts or unmounts. `hasMore` toggling false→true remounts the node with a
-  // fresh element, and this keeps the observer attached to the live node instead
-  // of a detached one.
   const [node, setNode] = useState<HTMLDivElement | null>(null)
   const [isIntersecting, setIsIntersecting] = useState(false)
 

--- a/web/components/layout/Page.tsx
+++ b/web/components/layout/Page.tsx
@@ -129,8 +129,6 @@ export const SurveyModal = () => {
     const setupSurvey = async () => {
       const now = new Date().getTime()
 
-      // Onboarding survey: shown once at the very beginning. Once the user has interacted
-      // with it (opened or dismissed) it is never shown again.
       if (config.onboardingSurveyUrl && onboardingSurveyCompleted === 0) {
         setSurveyType('onboarding')
         setSurveyUrl(await buildSurveyUrl(config.onboardingSurveyUrl, user.id))
@@ -138,8 +136,6 @@ export const SurveyModal = () => {
         return
       }
 
-      // Weekly survey: shown once the onboarding survey has been handled (or is not
-      // configured), then again at most once per week.
       const onboardingHandled = onboardingSurveyCompleted > 0 || !config.onboardingSurveyUrl
       if (config.weeklySurveyUrl && onboardingHandled && (weeklySurveyLastCompleted === 0 || now - weeklySurveyLastCompleted >= ONE_WEEK_MS)) {
         setSurveyType('weekly')
@@ -152,8 +148,6 @@ export const SurveyModal = () => {
     setupSurvey().catch(() => { })
   }, [config.onboardingSurveyUrl, config.weeklySurveyUrl, user?.id, onboardingSurveyCompleted, weeklySurveyLastCompleted, isSurveyOpen])
 
-  // Persist that the user interacted with the survey dialog so it does not annoy them
-  // again (onboarding: ever, weekly: until the next week).
   const persistInteraction = () => {
     const now = new Date().getTime()
     if (surveyType === 'onboarding') {

--- a/web/components/patients/PatientDetailView.tsx
+++ b/web/components/patients/PatientDetailView.tsx
@@ -96,7 +96,6 @@ export const PatientDetailView = ({
     const currentProperties = patientData.properties || []
     const propertyInputs: PropertyValueInput[] = []
 
-    // Add all existing properties except the one being changed
     for (const prop of currentProperties) {
       if (prop.definition.id !== definitionId) {
         propertyInputs.push({
@@ -113,7 +112,6 @@ export const PatientDetailView = ({
       }
     }
 
-    // Add the changed property if it's not null
     if (value !== null) {
       const newPropertyInput = convertPropertyValueToInput(definitionId, value)
       if (newPropertyInput) {

--- a/web/components/properties/PropertyEntry.tsx
+++ b/web/components/properties/PropertyEntry.tsx
@@ -29,7 +29,6 @@ type PropertyEntryProps = {
   readOnly?: boolean,
 }
 
-// TODO move to hightide
 export const PropertyEntry = ({
   value,
   name,

--- a/web/components/tables/PatientList.tsx
+++ b/web/components/tables/PatientList.tsx
@@ -114,16 +114,13 @@ type PatientListProps = {
   viewDefaultColumnOrder?: ColumnOrderState,
   readOnly?: boolean,
   hideSaveView?: boolean,
-  /** When set (e.g. on `/view/:id`), overwrite updates this saved view. */
   savedViewId?: string,
   onSavedViewCreated?: (id: string) => void,
   onPatientUpdated?: () => void,
   embedded?: boolean,
   embeddedPatients?: PatientViewModel[],
   embeddedOnRefetch?: () => void,
-  /** When set with embeddedPatients: client-side filter/sort/search on derived rows; show full toolbar. */
   derivedVirtualMode?: boolean,
-  /** Persist overwrite targets base view triple or related triple (opposite tab). */
   savedViewScope?: 'base' | 'related',
 }
 
@@ -1177,9 +1174,6 @@ export const PatientList = forwardRef<PatientListRef, PatientListProps>(({ initi
                 hasMore={hasMore}
                 isFetchingMore={isFetchingMore}
               />
-              {/* Always render the manual loader at the bottom: infinite-scroll
-                  auto-loading is unreliable on mobile, so the button is the
-                  dependable fallback for loading the next page by hand. */}
               <Button
                 color="neutral"
                 className="mt-2 w-full sm:w-auto self-center print:hidden"

--- a/web/components/tables/RowRefreshingGate.tsx
+++ b/web/components/tables/RowRefreshingGate.tsx
@@ -7,10 +7,6 @@ type RowRefreshingGateProps = HTMLAttributes<HTMLDivElement> & {
   children: ReactNode,
 }
 
-/**
- * Keeps the cell content visible while an entity is being refreshed, dimming it
- * and overlaying a spinner instead of replacing it with a loading placeholder.
- */
 export function RowRefreshingGate({ refreshing, children, className, ...restProps }: RowRefreshingGateProps) {
   return (
     <div className={clsx('relative min-h-8 min-w-0', className)} {...restProps}>

--- a/web/components/tables/TaskList.tsx
+++ b/web/components/tables/TaskList.tsx
@@ -62,7 +62,6 @@ export type TaskViewModel = {
   },
   assignee?: { id: string, name: string, avatarURL?: string | null, isOnline?: boolean | null },
   assigneeTeam?: { id: string, title: string },
-  /** Additional user assignees beyond the first (omit when team assignment). */
   additionalAssigneeCount?: number,
   done: boolean,
   sourceTaskPresetId?: string | null,
@@ -107,7 +106,6 @@ type TaskListProps = {
   hasMore?: boolean,
   isFetchingMore?: boolean,
   embedded?: boolean,
-  /** Row order and search already applied in parent (e.g. saved view derived task list). */
   virtualDerivedOrder?: boolean,
 }
 
@@ -1098,9 +1096,6 @@ export const TaskList = forwardRef<TaskListRef, TaskListProps>(({ tasks: initial
                   hasMore={effectiveHasMore}
                   isFetchingMore={isFetchingMore}
                 />
-                {/* Always render the manual loader at the bottom: infinite-scroll
-                    auto-loading is unreliable on mobile, so the button is the
-                    dependable fallback for loading the next page by hand. */}
                 <Button
                   color="neutral"
                   className="mt-2 w-full sm:w-auto self-center print:hidden"

--- a/web/components/tasks/TaskDetailView.tsx
+++ b/web/components/tasks/TaskDetailView.tsx
@@ -54,7 +54,6 @@ export const TaskDetailView = ({ taskId, onClose, onCreateSuccessClose, onListSy
     const currentProperties = taskData.properties || []
     const propertyInputs: PropertyValueInput[] = []
 
-    // Add all existing properties except the one being changed
     for (const prop of currentProperties) {
       if (prop.definition.id !== definitionId) {
         propertyInputs.push({
@@ -70,8 +69,6 @@ export const TaskDetailView = ({ taskId, onClose, onCreateSuccessClose, onListSy
         })
       }
     }
-
-    // Add the changed property if it's not null
 
     if (value !== null) {
       const newPropertyInput = convertPropertyValueToInput(definitionId, value)

--- a/web/components/views/SaveViewDialog.tsx
+++ b/web/components/views/SaveViewDialog.tsx
@@ -19,13 +19,11 @@ import { appendSavedViewToMySavedViewsCache } from '@/utils/savedViewsCache'
 type SaveViewDialogProps = {
   isOpen: boolean,
   onClose: () => void,
-  /** Entity this view is saved from */
   baseEntityType: SavedViewEntityType,
   filterDefinition: string,
   sortDefinition: string,
   parameters: string,
   presentation?: 'default' | 'fromSystemList',
-  /** Optional: navigate or toast after save */
   onCreated?: (id: string) => void,
 }
 

--- a/web/data/cache/persist.ts
+++ b/web/data/cache/persist.ts
@@ -30,7 +30,7 @@ export async function replayPendingMutations(cache: ApolloCache): Promise<void> 
       try {
         patch.apply(cache, record.variables)
       } catch {
-        //
+        void 0
       }
     }
     addPendingMutation(record)

--- a/web/data/hooks/usePaginatedEntityQuery.ts
+++ b/web/data/hooks/usePaginatedEntityQuery.ts
@@ -18,7 +18,6 @@ export type UsePaginatedEntityQueryResult<TItem> = {
   error: Error | undefined,
   totalCount: number | undefined,
   refetch: () => void,
-  /** Warm the Apollo cache for an arbitrary page without affecting the active query. */
   prefetchPage: (pageIndex: number) => void,
 }
 

--- a/web/data/mutations/runner.ts
+++ b/web/data/mutations/runner.ts
@@ -92,9 +92,6 @@ export async function mutateOptimistic<TData, TVariables>(
     }
     onSuccess?.(result.data, variables)
     schedulePersistCache(cache)
-    // Reload the mutated entity from the server so server-computed fields are
-    // reflected after our optimistic write. Fire-and-forget: the optimistic UI
-    // is already in place and the row dims via the refreshing gate meanwhile.
     if (typeof vars?.['id'] === 'string') {
       void reloadEntityAfterMutation(client, entityType, vars['id'])
     }
@@ -104,7 +101,7 @@ export async function mutateOptimistic<TData, TVariables>(
       try {
         patch.rollback(cache, variables)
       } catch {
-        //
+        void 0
       }
     }
     removePendingMutation(resolvedId)

--- a/web/data/subscriptions/handler.test.ts
+++ b/web/data/subscriptions/handler.test.ts
@@ -88,7 +88,6 @@ describe('reloadEntityAfterMutation', () => {
         writeQuery: vi.fn(),
       },
       refetchQueries: vi.fn().mockImplementation(() => {
-        // Capture the gate state while the reload is still in flight.
         gatedDuringRefetch = getRefreshingPatientIds().has('patient-1')
         return Promise.resolve([])
       }),
@@ -99,7 +98,6 @@ describe('reloadEntityAfterMutation', () => {
     expect(client.query).toHaveBeenCalled()
     expect(client.refetchQueries).toHaveBeenCalled()
     expect(gatedDuringRefetch).toBe(true)
-    // The gate is released once the reload settles.
     expect(getRefreshingPatientIds().has('patient-1')).toBe(false)
   })
 

--- a/web/data/subscriptions/handler.ts
+++ b/web/data/subscriptions/handler.ts
@@ -49,9 +49,6 @@ function isLikelyEcho(
   const recent = recentMutationsByEntity.get(key)
   if (!recent) return false
   if (payloadClientMutationId) {
-    // An explicit mutation id is authoritative: it is an echo only when it
-    // matches our own in-flight mutation. A different id is a concurrent change
-    // from another client and must never be suppressed.
     return payloadClientMutationId === recent.clientMutationId
   }
   if (Date.now() - recent.at < ECHO_WINDOW_MS) {
@@ -188,20 +185,6 @@ export function mergeSubscriptionIntoCache(
   return Promise.resolve()
 }
 
-/**
- * Reload an entity from the server after we mutated it ourselves.
- *
- * Our optimistic update only writes the fields we know about, and the
- * subscription echo for our own change is intentionally suppressed (see
- * `isLikelyEcho`), so without this the row would keep showing the optimistic
- * value and never pick up server-computed fields (e.g. the derived full `name`,
- * `updateDate`, or normalized property values). Refetching the active queries
- * for the entity reconciles the visible list/detail with the server while the
- * row is dimmed by the refreshing gate, mirroring the realtime update path.
- *
- * Must be called *after* `clearEntityMutated`, otherwise the echo guard inside
- * the merge helpers would short-circuit the reload.
- */
 export async function reloadEntityAfterMutation(
   client: ApolloClient,
   entityType: 'Task' | 'Patient',
@@ -209,39 +192,30 @@ export async function reloadEntityAfterMutation(
 ): Promise<void> {
   if (entityType === 'Task') {
     addRefreshingTask(entityId)
-    try {
-      await mergeTaskUpdatedIntoCache(
-        client,
-        entityId,
-        { taskId: entityId },
-        { conflictStrategy: 'server-wins' }
-      )
-      await client.refetchQueries({
+    await mergeTaskUpdatedIntoCache(
+      client,
+      entityId,
+      { taskId: entityId },
+      { conflictStrategy: 'server-wins' }
+    )
+      .then(() => client.refetchQueries({
         include: [getParsedDocument(GetTasksDocument), getParsedDocument(GetPatientsDocument)],
-      })
-    } catch {
-      // A failed reload must never surface as a mutation failure; the optimistic
-      // value stays until the next refetch or subscription event.
-    } finally {
-      removeRefreshingTask(entityId)
-    }
+      }))
+      .catch(() => {})
+      .finally(() => removeRefreshingTask(entityId))
     return
   }
 
   addRefreshingPatient(entityId)
-  try {
-    await mergePatientUpdatedIntoCache(
-      client,
-      entityId,
-      { patientId: entityId },
-      { conflictStrategy: 'server-wins' }
-    )
-    await client.refetchQueries({
+  await mergePatientUpdatedIntoCache(
+    client,
+    entityId,
+    { patientId: entityId },
+    { conflictStrategy: 'server-wins' }
+  )
+    .then(() => client.refetchQueries({
       include: [getParsedDocument(GetPatientsDocument), getParsedDocument(GetTasksDocument)],
-    })
-  } catch {
-    // See above: keep the optimistic value rather than failing the mutation.
-  } finally {
-    removeRefreshingPatient(entityId)
-  }
+    }))
+    .catch(() => {})
+    .finally(() => removeRefreshingPatient(entityId))
 }

--- a/web/globals.css
+++ b/web/globals.css
@@ -15,14 +15,6 @@
 }
 
 @layer utilities {
-  /*
-   * Enables momentum scrolling for overflow containers (e.g. horizontally
-   * scrollable tables) without constraining `touch-action`. We intentionally
-   * avoid Tailwind's `touch-pan-x` utility here: that sets
-   * `touch-action: pan-x`, which makes the browser treat the element as
-   * horizontal-only and swallows vertical scroll gestures, breaking vertical
-   * touch scrolling of the surrounding page on phones and tablets.
-   */
   .hw-touch-scroll {
     -webkit-overflow-scrolling: touch;
   }

--- a/web/hooks/useAccumulatedPagination.test.ts
+++ b/web/hooks/useAccumulatedPagination.test.ts
@@ -43,9 +43,6 @@ describe('computePaginationBounds', () => {
   })
 
   it('does not loop when the page index is past the end of a shrunken result set', () => {
-    // Reproduces the reported bug: total dropped to 20 (one page) while the
-    // view was paged far ahead, so every fetch returned an empty page and the
-    // sentinel kept asking for the next one.
     const { lastAvailablePage, hasMore } = computePaginationBounds({
       totalCount: 20,
       pageSize: PAGE_SIZE,

--- a/web/hooks/useAccumulatedPagination.ts
+++ b/web/hooks/useAccumulatedPagination.ts
@@ -2,14 +2,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 const DEFAULT_PREFETCH_PAGES = 2
 
-/**
- * Pure derivation of the pagination boundaries. Kept separate so the
- * "stop at the end" logic can be unit-tested without rendering the hook.
- *
- * `lastAvailablePage` is the highest page index that still maps onto real data;
- * fetching beyond it only yields empty pages (offset past the total), which is
- * what previously kept the infinite-scroll sentinel looping forever.
- */
 export function computePaginationBounds(options: {
   totalCount: number | undefined,
   pageSize: number,
@@ -30,8 +22,6 @@ export function computePaginationBounds(options: {
 }
 
 function reconcileFirstPage<T extends { id: string }>(prev: T[], incoming: T[]): T[] {
-  // When more pages were already accumulated, keep the tail and only refresh the
-  // leading page so a page-0 background refetch never shrinks the visible list.
   if (incoming.length === 0) return prev
   if (prev.length <= incoming.length) return incoming
   const incomingIds = new Set(incoming.map(x => x.id))
@@ -47,9 +37,7 @@ export function useAccumulatedPagination<T extends { id: string }>(options: {
   totalCount: number | undefined,
   loading: boolean,
   pageSize: number,
-  /** Warms the cache for upcoming pages so scrolling stays instant. */
   prefetchPage?: (pageIndex: number) => void,
-  /** How many pages ahead to keep ready. Defaults to 2. */
   prefetchPages?: number,
 }): {
   accumulated: T[],
@@ -75,16 +63,10 @@ export function useAccumulatedPagination<T extends { id: string }>(options: {
   useEffect(() => {
     if (pageData === undefined || loading) return
     if (pageIndex === 0) {
-      // Reconcile the first page in place so unchanged rows keep their position
-      // and the table is not remounted on every background refetch.
       setAccumulated(prev => reconcileFirstPage(prev, pageData))
       return
     }
     setAccumulated(prev => {
-      // Refresh already-accumulated rows in place with the freshly fetched copy
-      // (so a row reloaded after an edit reflects the server value instead of the
-      // stale object captured when the page was first appended), then append any
-      // rows we have not seen yet.
       const incomingById = new Map(pageData.map(item => [item.id, item]))
       const existingIds = new Set(prev.map(item => item.id))
       const next = prev.map(item => incomingById.get(item.id) ?? item)
@@ -95,11 +77,6 @@ export function useAccumulatedPagination<T extends { id: string }>(options: {
     })
   }, [pageData, pageIndex, loading])
 
-  // `lastAvailablePage` is the highest page index that still maps onto real data;
-  // `hasMore` is true only when more rows are expected *and* a further page
-  // exists to fetch. Gating on the page index keeps us from offering "Load more"
-  // (or auto-loading) when the visible list is empty but a stale total still
-  // claims rows exist.
   const { lastAvailablePage, hasMore } = useMemo(
     () => computePaginationBounds({
       totalCount,
@@ -110,11 +87,6 @@ export function useAccumulatedPagination<T extends { id: string }>(options: {
     [totalCount, pageSize, pageIndex, accumulated.length]
   )
 
-  // Recover from an out-of-range page index. When the result set shrinks while a
-  // later page is selected (e.g. switching to a custom view with fewer rows),
-  // the active query would otherwise keep requesting empty pages past the end,
-  // never growing `accumulated`, leaving `hasMore` permanently true and spinning
-  // the infinite-scroll sentinel in a loading loop.
   useEffect(() => {
     if (lastAvailablePage == null) return
     if (pageIndex > lastAvailablePage) {

--- a/web/hooks/useStorage.ts
+++ b/web/hooks/useStorage.ts
@@ -55,7 +55,7 @@ export function useStorage<T>(options: UseStorageOptions<T>): UseStorageResult<T
           try {
             window.localStorage.setItem(key, serialize(next))
           } catch {
-            // ignore storage errors
+            void 0
           }
         }
         return next

--- a/web/pages/location/[id].tsx
+++ b/web/pages/location/[id].tsx
@@ -167,7 +167,7 @@ const LocationPage: NextPage = () => {
       current = current.parent || null
     }
 
-    return chain.reverse() // Reverse to get root-to-parent order
+    return chain.reverse()
   }, [locationData])
 
   return (

--- a/web/pages/settings/index.tsx
+++ b/web/pages/settings/index.tsx
@@ -87,14 +87,12 @@ const SettingsPage: NextPage = () => {
   const handleOpenOnboardingSurvey = async () => {
     if (!user?.id || !config.onboardingSurveyUrl) return
     await openSurvey(config.onboardingSurveyUrl, user.id)
-    // Mark as handled so the popup does not show again after taking it from the settings.
     setOnboardingSurveyCompleted(new Date().getTime())
   }
 
   const handleOpenWeeklySurvey = async () => {
     if (!user?.id || !config.weeklySurveyUrl) return
     await openSurvey(config.weeklySurveyUrl, user.id)
-    // Mark as handled so the weekly popup does not show again until the next week.
     setWeeklySurveyLastCompleted(new Date().getTime())
   }
 

--- a/web/style/colors.css
+++ b/web/style/colors.css
@@ -1,5 +1,4 @@
 @theme {
-  /* Default Color Overwrites */
   --color-background: #EEEEEE;
   --color-foreground: #000000;
 
@@ -51,13 +50,10 @@
 
 @layer base {
 
-  /* Here are overrides for the light theme */
   @variant dark {
-    /* Header */
     --color-header-background: var(--color-black);
     --color-header-text: var(--color-white);
 
-    /* Location colors */
     --color-location-hospital: var(--color-red-900);
     --color-location-on-hospital: var(--color-red-300);
 

--- a/web/style/table-autosize.css
+++ b/web/style/table-autosize.css
@@ -1,14 +1,3 @@
-/*
- * Content-aware sizing for the task/patient tables. Scoped to
- * `.hw-autosize-table` so other tables (settings, properties) keep the default
- * fixed layout from @helpwave/hightide.
- *
- * Switching to `table-layout: auto` lets columns grow to fit their content
- * (long values, chips) instead of clipping/overflowing a fixed width, while the
- * surrounding container keeps horizontal scrolling when the total exceeds the
- * viewport. Multi-value cells (e.g. multi-select chips) already wrap, so they
- * now flow onto additional lines instead of spilling to the right.
- */
 table[data-name="table"].hw-autosize-table {
   table-layout: auto;
   width: 100% !important;

--- a/web/style/table-printing.css
+++ b/web/style/table-printing.css
@@ -1,9 +1,6 @@
 @media print {
   @page {
     size: A4 landscape;
-    /* Give the printout breathing room on every edge. The table below is
-       constrained to the resulting printable width, so the margins are added
-       without clipping any columns. */
     margin: 1cm;
   }
 
@@ -68,9 +65,6 @@
     @apply !text-sm;
     page-break-inside: auto;
 
-    /* Fixed layout makes every column share the printable width evenly instead
-       of growing to fit its content, so a wide table scales down to the page
-       (with its new margins) rather than overflowing and getting clipped. */
     table-layout: fixed !important;
     border-collapse: collapse;
     border: 1px solid black;
@@ -81,8 +75,6 @@
     break-after: avoid;
   }
 
-  /* Drop any per-column widths the on-screen auto-size feature applied so the
-     fixed layout can share the printable width evenly across all columns. */
   .print-content colgroup col {
     width: auto !important;
   }
@@ -97,9 +89,6 @@
     @apply !text-sm;
     overflow: visible !important;
     white-space: pre-wrap !important;
-    /* With fixed table layout columns can get narrow, so allow long values to
-       wrap (and break mid-word as a last resort) instead of spilling past the
-       column edge and being clipped at the page margin. */
     word-break: break-word !important;
     overflow-wrap: anywhere !important;
   }
@@ -149,13 +138,6 @@
     display: none !important;
   }
 
-  /*
-   * Inline-editable property cells render their value inside a <button>
-   * trigger (see EditablePropertyCell / InTable*EditPopUp). The generic
-   * `button { display: none }` rule below would otherwise wipe those values
-   * out of the printout, so keep buttons that live inside table cells visible
-   * and strip their interactive chrome so they read as plain text.
-   */
   .print-content thead tr th button,
   .print-content tbody tr td button {
     display: inline-flex !important;

--- a/web/utils/propertyFilterMapping.test.ts
+++ b/web/utils/propertyFilterMapping.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { FieldType } from '@/api/gql/generated'
+import { getPropertyFilterFn } from '@/utils/propertyFilterMapping'
+
+describe('getPropertyFilterFn', () => {
+  it.each([
+    [FieldType.FieldTypeCheckbox, 'boolean'],
+    [FieldType.FieldTypeDate, 'date'],
+    [FieldType.FieldTypeDateTime, 'dateTime'],
+    [FieldType.FieldTypeNumber, 'number'],
+    [FieldType.FieldTypeSelect, 'singleTag'],
+    [FieldType.FieldTypeMultiSelect, 'multiTags'],
+    [FieldType.FieldTypeUser, 'text'],
+    [FieldType.FieldTypeText, 'text'],
+  ])('maps %s to %s', (fieldType, expected) => {
+    expect(getPropertyFilterFn(fieldType)).toBe(expected)
+  })
+
+  it('falls back to text for unknown field types', () => {
+    expect(getPropertyFilterFn('SOMETHING_ELSE' as FieldType)).toBe('text')
+  })
+})

--- a/web/utils/propertyFilterMapping.ts
+++ b/web/utils/propertyFilterMapping.ts
@@ -1,14 +1,6 @@
 import { FieldType } from '@/api/gql/generated'
 import type { DataType } from '@helpwave/hightide'
 
-/**
- * Maps a FieldType to the appropriate filter function name for TanStack Table.
- * This ensures consistent filter behavior across all property columns.
- *
- * Differentiates between:
- * - date vs datetime (for proper date/time filtering)
- * - tags (multi-select) vs tags_single (single select)
- */
 export function getPropertyFilterFn(fieldType: FieldType): DataType {
   switch (fieldType) {
   case FieldType.FieldTypeCheckbox:

--- a/web/utils/scrollableAncestor.ts
+++ b/web/utils/scrollableAncestor.ts
@@ -1,26 +1,7 @@
-/**
- * Helpers for locating the scroll container an element actually lives in.
- *
- * Infinite-scroll relies on an IntersectionObserver. When `root` is left as the
- * viewport but the content is rendered inside a nested `overflow-y-auto`
- * container (as the app shell does in `Page`), intermediate scroll containers
- * clip the observed target, so a generous `rootMargin` lookahead is silently
- * ignored — the sentinel only intersects once it reaches the very bottom.
- * Observing against the real scroll container restores the "load before the
- * bottom is reached" behaviour.
- */
-
-/** A computed `overflow-y` value that lets the element scroll its content. */
 export function isScrollableOverflowY(overflowY: string): boolean {
   return overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay'
 }
 
-/**
- * Walks up from `node` and returns the nearest ancestor that scrolls vertically.
- * Stops at (and ignores) the document root, where `root: null` (the viewport) is
- * already the correct IntersectionObserver root. Returns `null` when no nested
- * scroll container exists, which the caller should treat as "use the viewport".
- */
 export function findScrollableAncestor(node: Element | null): HTMLElement | null {
   if (typeof window === 'undefined') return null
   let current = node?.parentElement ?? null

--- a/web/utils/survey.test.ts
+++ b/web/utils/survey.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { hashString } from '@/utils/hash'
+import { buildSurveyUrl, ONE_WEEK_MS, surveyStorageKeys } from '@/utils/survey'
+
+describe('survey constants', () => {
+  it('exposes the storage keys and a one-week interval', () => {
+    expect(surveyStorageKeys.onboardingCompleted).toBe('onboarding-survey-completed')
+    expect(surveyStorageKeys.weeklyLastCompleted).toBe('weekly-survey-last-completed')
+    expect(ONE_WEEK_MS).toBe(1000 * 60 * 60 * 24 * 7)
+  })
+})
+
+describe('buildSurveyUrl', () => {
+  it('appends an anonymized (hashed) user id as the "a" query parameter', async () => {
+    const url = await buildSurveyUrl('https://survey.example/form', 'user-123')
+    const parsed = new URL(url)
+    expect(parsed.searchParams.get('a')).toBe(await hashString('user-123'))
+    expect(parsed.origin + parsed.pathname).toBe('https://survey.example/form')
+  })
+
+  it('does not expose the raw user id', async () => {
+    const url = await buildSurveyUrl('https://survey.example/form', 'secret-user')
+    expect(url).not.toContain('secret-user')
+  })
+
+  it('preserves existing query parameters on the base url', async () => {
+    const url = await buildSurveyUrl('https://survey.example/form?lang=de', 'user-123')
+    const parsed = new URL(url)
+    expect(parsed.searchParams.get('lang')).toBe('de')
+    expect(parsed.searchParams.get('a')).toBeTruthy()
+  })
+})

--- a/web/utils/survey.ts
+++ b/web/utils/survey.ts
@@ -2,17 +2,6 @@ import { hashString } from '@/utils/hash'
 
 export type SurveyType = 'onboarding' | 'weekly'
 
-/**
- * localStorage keys tracking whether the user already interacted with a survey dialog.
- *
- * - `onboardingCompleted`: timestamp of the interaction with the onboarding survey
- *   (0 = the user has not interacted yet). The onboarding survey is shown only once.
- * - `weeklyLastCompleted`: timestamp of the last interaction with the weekly survey
- *   (0 = never). The weekly survey is shown again once a week has passed.
- *
- * "Interaction" means the user either opened the survey or dismissed the dialog. In
- * both cases we persist it so the popup does not keep annoying the user.
- */
 export const surveyStorageKeys = {
   onboardingCompleted: 'onboarding-survey-completed',
   weeklyLastCompleted: 'weekly-survey-last-completed',
@@ -20,10 +9,6 @@ export const surveyStorageKeys = {
 
 export const ONE_WEEK_MS = 1000 * 60 * 60 * 24 * 7
 
-/**
- * Builds the survey URL with an anonymized (hashed) user id appended as the `a` query
- * parameter, so survey responses can be de-duplicated without exposing the real user id.
- */
 export const buildSurveyUrl = async (baseUrl: string, userId: string): Promise<string> => {
   const hashedUserId = await hashString(userId)
   const url = new URL(baseUrl)
@@ -31,7 +16,6 @@ export const buildSurveyUrl = async (baseUrl: string, userId: string): Promise<s
   return url.toString()
 }
 
-/** Opens the survey in a new tab with the anonymized user id appended. */
 export const openSurvey = async (baseUrl: string, userId: string): Promise<void> => {
   const url = await buildSurveyUrl(baseUrl, userId)
   window.open(url, '_blank', 'noopener,noreferrer')

--- a/web/utils/viewDefinition.test.ts
+++ b/web/utils/viewDefinition.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest'
+import type { ColumnFiltersState, SortingState } from '@tanstack/react-table'
+import {
+  columnOrderMatchesBaselineForDirty,
+  deserializeColumnFiltersFromView,
+  deserializeSortingFromView,
+  expandVisibilityWithPropertyColumnDefaults,
+  hasActiveLocationFilter,
+  normalizedVisibilityForViewCompare,
+  parseViewParameters,
+  serializeColumnFiltersForView,
+  serializeSortingForView,
+  tableViewStateMatchesBaseline,
+  visibilityMatchesViewBaseline
+} from '@/utils/viewDefinition'
+
+describe('hasActiveLocationFilter', () => {
+  it('detects a position filter with a single uuid value', () => {
+    const filters = [
+      { id: 'position', value: { parameter: { uuidValue: 'loc-1' } } },
+    ] as unknown as ColumnFiltersState
+    expect(hasActiveLocationFilter(filters)).toBe(true)
+  })
+
+  it('detects a locationSubtree filter with uuid values', () => {
+    const filters = [
+      { id: 'locationSubtree', value: { parameter: { uuidValues: ['loc-1'] } } },
+    ] as unknown as ColumnFiltersState
+    expect(hasActiveLocationFilter(filters)).toBe(true)
+  })
+
+  it('ignores non-location filters and empty parameters', () => {
+    const filters = [
+      { id: 'name', value: { parameter: { uuidValue: 'x' } } },
+      { id: 'position', value: { parameter: { uuidValue: '' } } },
+      { id: 'position', value: { parameter: { uuidValues: [] } } },
+    ] as unknown as ColumnFiltersState
+    expect(hasActiveLocationFilter(filters)).toBe(false)
+  })
+})
+
+describe('normalizedVisibilityForViewCompare', () => {
+  it('is independent of key insertion order', () => {
+    expect(normalizedVisibilityForViewCompare({ a: true, b: false }))
+      .toBe(normalizedVisibilityForViewCompare({ b: false, a: true }))
+  })
+
+  it('matches an equivalent baseline regardless of order', () => {
+    expect(visibilityMatchesViewBaseline({ a: true, b: false }, { b: false, a: true })).toBe(true)
+    expect(visibilityMatchesViewBaseline({ a: true }, { a: false })).toBe(false)
+  })
+})
+
+describe('expandVisibilityWithPropertyColumnDefaults', () => {
+  it('defaults unknown property columns to hidden without overriding explicit values', () => {
+    const result = expandVisibilityWithPropertyColumnDefaults(
+      { property_1: true },
+      ['property_1', 'property_2']
+    )
+    expect(result).toEqual({ property_1: true, property_2: false })
+  })
+
+  it('returns the input untouched when there are no property columns', () => {
+    const input = { a: true }
+    expect(expandVisibilityWithPropertyColumnDefaults(input, [])).toBe(input)
+  })
+})
+
+describe('columnOrderMatchesBaselineForDirty', () => {
+  it('treats an empty baseline as always matching', () => {
+    expect(columnOrderMatchesBaselineForDirty(['a', 'b'], [])).toBe(true)
+  })
+
+  it('compares against a non-empty baseline exactly', () => {
+    expect(columnOrderMatchesBaselineForDirty(['a', 'b'], ['a', 'b'])).toBe(true)
+    expect(columnOrderMatchesBaselineForDirty(['b', 'a'], ['a', 'b'])).toBe(false)
+  })
+})
+
+describe('parseViewParameters', () => {
+  it('parses a valid object', () => {
+    expect(parseViewParameters('{"searchQuery":"hi"}')).toEqual({ searchQuery: 'hi' })
+  })
+
+  it('returns an empty object for invalid json or non-objects', () => {
+    expect(parseViewParameters('not json')).toEqual({})
+    expect(parseViewParameters('42')).toEqual({})
+    expect(parseViewParameters('null')).toEqual({})
+  })
+})
+
+describe('column filter serialization round-trip', () => {
+  it('serializes date parameters to ISO strings and restores them as Date instances', () => {
+    const date = new Date('2026-01-02T03:04:05.000Z')
+    const filters = [
+      {
+        id: 'dueDate',
+        value: {
+          operator: 'between',
+          dataType: 'date',
+          parameter: { dateValue: date },
+        },
+      },
+    ] as unknown as ColumnFiltersState
+
+    const serialized = serializeColumnFiltersForView(filters)
+    expect(serialized).toContain('2026-01-02T03:04:05.000Z')
+
+    const restored = deserializeColumnFiltersFromView(serialized)
+    const restoredDate = (restored[0]!.value as { parameter: { dateValue?: Date } }).parameter.dateValue
+    expect(restoredDate).toBeInstanceOf(Date)
+    expect(restoredDate?.toISOString()).toBe(date.toISOString())
+  })
+
+  it('remaps the legacy locationSubtree id to position on deserialize', () => {
+    const json = JSON.stringify([
+      { id: 'locationSubtree', value: { operator: 'eq', dataType: 'text', parameter: {} } },
+    ])
+    expect(deserializeColumnFiltersFromView(json)[0]!.id).toBe('position')
+  })
+
+  it('returns an empty array for malformed filter json', () => {
+    expect(deserializeColumnFiltersFromView('not json')).toEqual([])
+  })
+})
+
+describe('sorting serialization', () => {
+  it('round-trips a sorting state', () => {
+    const sorting = [{ id: 'dueDate', desc: true }] as SortingState
+    expect(deserializeSortingFromView(serializeSortingForView(sorting))).toEqual(sorting)
+  })
+
+  it('returns an empty array for non-array or malformed json', () => {
+    expect(deserializeSortingFromView('{}')).toEqual([])
+    expect(deserializeSortingFromView('not json')).toEqual([])
+  })
+})
+
+describe('tableViewStateMatchesBaseline', () => {
+  const base = {
+    filters: [] as ColumnFiltersState,
+    baselineFilters: [] as ColumnFiltersState,
+    sorting: [] as SortingState,
+    baselineSorting: [] as SortingState,
+    searchQuery: '',
+    baselineSearch: '',
+    columnVisibility: {},
+    baselineColumnVisibility: {},
+    columnOrder: [],
+    baselineColumnOrder: [],
+    propertyColumnIds: [],
+  }
+
+  it('returns true when nothing diverges from the baseline', () => {
+    expect(tableViewStateMatchesBaseline(base)).toBe(true)
+  })
+
+  it('returns false when the search query diverges', () => {
+    expect(tableViewStateMatchesBaseline({ ...base, searchQuery: 'changed' })).toBe(false)
+  })
+
+  it('returns false when sorting diverges', () => {
+    expect(tableViewStateMatchesBaseline({
+      ...base,
+      sorting: [{ id: 'dueDate', desc: true }] as SortingState,
+    })).toBe(false)
+  })
+})

--- a/web/utils/viewDefinition.ts
+++ b/web/utils/viewDefinition.ts
@@ -109,7 +109,6 @@ export function stringifyViewParameters(p: ViewParameters): string {
   return JSON.stringify(p)
 }
 
-/** Wire format for `filterDefinition` on saved views (JSON string). */
 export function serializeColumnFiltersForView(filters: ColumnFiltersState): string {
   const mappedColumnFilter = filters.map((filter) => {
     const tableFilterValue = filter.value as FilterValue


### PR DESCRIPTION
## What

Code cleanup across the frontend (`web/`) and backend (`backend/`), following the project's self-documenting-code convention (AGENTS.md §10: "write self-explanatory code", no comments).

### Comment removal
- Removed explanatory comments from frontend (`.ts`, `.tsx`, `.css`) and backend (`.py`) source.
- **Preserved** functional directives — flake8 `# noqa: F401` re-export suppressions, and `eslint-disable` directives inside generated files.
- **Left generated artifacts untouched** (`web/api/gql/generated.ts`, `web/i18n/translations.ts`, `next-env.d.ts`, DB migrations).

### Readability / lint-safety
- Replaced comment-only empty `catch` blocks with explicit no-ops so they remain lint-clean (the `no-empty` rule requires a non-empty body).
- Rewrote the post-mutation entity reload (`reloadEntityAfterMutation`) from a `try/catch/finally` that depended on a comment into an equivalent promise chain. Behavior is unchanged and covered by the existing handler tests.

### Tests added (coverage)
- **Backend unit tests:**
  - `normalize_datetime_to_utc` (naive / UTC-aware / offset / `None`).
  - `LocationValidator` kind checks (`validate_kind`, `validate_position_kind`, `validate_team_kind`).
  - Task-graph helpers: more `validate_task_graph_dict` edge cases + `graph_dict_from_preset_inputs`.
- **Frontend unit tests:**
  - `viewDefinition` helpers (filter/sort serialization round-trips, visibility/order baseline comparisons, `parseViewParameters`).
  - `getPropertyFilterFn` field-type → data-type mapping.
  - `buildSurveyUrl` anonymized (hashed) user-id query param.
- **E2E:** a resilient smoke spec (document shell, mobile viewport, core entity routes).

## Validation
All run locally against Postgres + Redis matching the CI services:
- Backend: `flake8` clean; `pytest tests/unit tests/integration` → **72 passed** (was 48).
- Frontend: `tsc --noEmit && eslint .` clean; `vitest run` → **55 passed** (was 23); `check-translations` clean.

No behavior changes intended; no generated files edited by hand.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VAD869ozX1keur9gh7yv2P)_