### PR TITLE
fix(web): live-update list rows on edit and shrink chip cell height

### DIFF
--- a/web/components/properties/EditablePropertyCell.tsx
+++ b/web/components/properties/EditablePropertyCell.tsx
@@ -19,7 +19,7 @@ export type EditablePropertyCellProps = {
 }
 
 const editableTriggerButtonProps = {
-  className: 'justify-between group gap-x-2 w-full min-w-32 max-w-full h-auto max-h-none p-2 font-normal text-left',
+  className: 'justify-between group gap-x-2 w-full min-w-32 max-w-full h-auto max-h-none px-2 py-1 font-normal text-left',
 } as const
 
 function stopRowActivation(e: React.SyntheticEvent) {

--- a/web/components/properties/PropertyCell.tsx
+++ b/web/components/properties/PropertyCell.tsx
@@ -27,6 +27,7 @@ export const PropertyCell = ({
   case FieldType.FieldTypeCheckbox:
     return (
       <Chip
+        size="sm"
         className="coloring-tonal"
         color={property.booleanValue ? 'positive' : 'negative'}
       >
@@ -71,7 +72,7 @@ export const PropertyCell = ({
       : property.selectValue
     return (
       <div className="flex flex-wrap gap-1">
-        <Chip className="primary coloring-tonal">
+        <Chip size="sm" className="primary coloring-tonal">
           {selectOptionName}
         </Chip>
       </div>
@@ -89,7 +90,7 @@ export const PropertyCell = ({
             ? property.definition.options[parseInt(multiSelectOptionIndex, 10)]
             : val
           return (
-            <Chip key={val} className="primary coloring-tonal">
+            <Chip key={val} size="sm" className="primary coloring-tonal">
               {multiSelectOptionName}
             </Chip>
           )

--- a/web/components/tables/PatientList.tsx
+++ b/web/components/tables/PatientList.tsx
@@ -377,7 +377,7 @@ export const PatientList = forwardRef<PatientListRef, PatientListProps>(({ initi
   )
 
   const lastTotalCountRef = useRef<number | undefined>(undefined)
-  const { data: patientsData, refetch, totalCount, loading: patientsLoading, prefetchPage } = usePatientsPaginated(
+  const { data: patientsData, refetch, totalCount, loading: patientsLoading, prefetchPage, readCachedPage, watchCachedPage } = usePatientsPaginated(
     {
       locationId: hasLocationFilter ? undefined : (locationId || undefined),
       rootLocationIds: hasLocationFilter || locationId
@@ -405,6 +405,8 @@ export const PatientList = forwardRef<PatientListRef, PatientListProps>(({ initi
     loading: patientsLoading,
     pageSize: LIST_PAGE_SIZE,
     prefetchPage,
+    readCachedPage,
+    watchCachedPage,
   })
 
   const mapPatientRow = useCallback((p: GetPatientsQuery['patients'][0]): PatientViewModel => {

--- a/web/data/hooks/usePaginatedEntityQuery.ts
+++ b/web/data/hooks/usePaginatedEntityQuery.ts
@@ -19,6 +19,8 @@ export type UsePaginatedEntityQueryResult<TItem> = {
   totalCount: number | undefined,
   refetch: () => void,
   prefetchPage: (pageIndex: number) => void,
+  readCachedPage: (pageIndex: number) => TItem[] | undefined,
+  watchCachedPage: (pageIndex: number, onChange: () => void) => () => void,
 }
 
 type VariablesWithPagination = {
@@ -80,6 +82,31 @@ export function usePaginatedEntityQuery<
     }).catch(() => {})
   }, [client, skipQuery, document, baseVariables, pageSize])
 
+  const readCachedPage = useCallback((pageIndex: number): TItem[] | undefined => {
+    if (!client || skipQuery === true || pageIndex < 0) return undefined
+    try {
+      const cached = client.cache.readQuery<TQueryData>({
+        query: getParsedDocument(document),
+        variables: { ...baseVariables, pagination: { pageIndex, pageSize } },
+        optimistic: true,
+      })
+      if (cached == null) return undefined
+      return extractItemsRef.current(cached)
+    } catch {
+      return undefined
+    }
+  }, [client, skipQuery, document, baseVariables, pageSize])
+
+  const watchCachedPage = useCallback((pageIndex: number, onChange: () => void): (() => void) => {
+    if (!client || skipQuery === true || pageIndex < 0) return () => {}
+    return client.cache.watch({
+      query: getParsedDocument(document),
+      variables: { ...baseVariables, pagination: { pageIndex, pageSize } },
+      optimistic: true,
+      callback: () => { onChange() },
+    })
+  }, [client, skipQuery, document, baseVariables, pageSize])
+
   return {
     data,
     loading: result.loading,
@@ -87,5 +114,7 @@ export function usePaginatedEntityQuery<
     totalCount,
     refetch,
     prefetchPage,
+    readCachedPage,
+    watchCachedPage,
   }
 }

--- a/web/data/hooks/usePatientsPaginated.ts
+++ b/web/data/hooks/usePatientsPaginated.ts
@@ -21,6 +21,8 @@ export type UsePatientsPaginatedResult = {
   totalCount: number | undefined,
   refetch: () => void,
   prefetchPage: (pageIndex: number) => void,
+  readCachedPage: (pageIndex: number) => GetPatientsQuery['patients'] | undefined,
+  watchCachedPage: (pageIndex: number, onChange: () => void) => () => void,
 }
 
 function propertyFingerprint(prop: { definition?: { id: string }, textValue?: string | null, numberValue?: number | null, userValue?: string | null }): string {

--- a/web/data/hooks/useTasksPaginated.ts
+++ b/web/data/hooks/useTasksPaginated.ts
@@ -20,6 +20,8 @@ export type UseTasksPaginatedResult = {
   totalCount: number | undefined,
   refetch: () => void,
   prefetchPage: (pageIndex: number) => void,
+  readCachedPage: (pageIndex: number) => GetTasksQuery['tasks'] | undefined,
+  watchCachedPage: (pageIndex: number, onChange: () => void) => () => void,
 }
 
 export function useTasksPaginated(

--- a/web/hooks/useAccumulatedPagination.test.ts
+++ b/web/hooks/useAccumulatedPagination.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { computePaginationBounds } from './useAccumulatedPagination'
+import { computePaginationBounds, mergePagesById } from './useAccumulatedPagination'
 
 const PAGE_SIZE = 25
 
@@ -59,5 +59,38 @@ describe('computePaginationBounds', () => {
     })
     expect(lastAvailablePage).toBeUndefined()
     expect(hasMore).toBe(true)
+  })
+})
+
+describe('mergePagesById', () => {
+  it('concatenates pages in order', () => {
+    const merged = mergePagesById([
+      [{ id: 'a' }, { id: 'b' }],
+      [{ id: 'c' }],
+    ])
+    expect(merged.map(x => x.id)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('skips not-yet-loaded (undefined) pages without losing later pages', () => {
+    const merged = mergePagesById([
+      [{ id: 'a' }],
+      undefined,
+      [{ id: 'c' }],
+    ])
+    expect(merged.map(x => x.id)).toEqual(['a', 'c'])
+  })
+
+  it('keeps the first occurrence when an id appears on multiple pages', () => {
+    const first = { id: 'a', v: 1 }
+    const duplicate = { id: 'a', v: 2 }
+    const merged = mergePagesById([[first], [duplicate, { id: 'b', v: 3 }]])
+    expect(merged).toEqual([first, { id: 'b', v: 3 }])
+  })
+
+  it('reflects fresh item references from the cache (live updates)', () => {
+    const stale = { id: 'a', name: 'old' }
+    const fresh = { id: 'a', name: 'new' }
+    expect(mergePagesById([[stale]])[0]).toBe(stale)
+    expect(mergePagesById([[fresh]])[0]).toBe(fresh)
   })
 })

--- a/web/hooks/useAccumulatedPagination.ts
+++ b/web/hooks/useAccumulatedPagination.ts
@@ -29,6 +29,31 @@ function reconcileFirstPage<T extends { id: string }>(prev: T[], incoming: T[]):
   return [...incoming, ...tail]
 }
 
+function sameItems<T extends { id: string }>(a: T[], b: T[]): boolean {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false
+  }
+  return true
+}
+
+export function mergePagesById<T extends { id: string }>(
+  pages: ReadonlyArray<readonly T[] | undefined>
+): T[] {
+  const out: T[] = []
+  const seen = new Set<string>()
+  for (const page of pages) {
+    if (!page) continue
+    for (const item of page) {
+      if (!seen.has(item.id)) {
+        seen.add(item.id)
+        out.push(item)
+      }
+    }
+  }
+  return out
+}
+
 export function useAccumulatedPagination<T extends { id: string }>(options: {
   resetKey: string,
   pageData: T[] | undefined,
@@ -39,6 +64,8 @@ export function useAccumulatedPagination<T extends { id: string }>(options: {
   pageSize: number,
   prefetchPage?: (pageIndex: number) => void,
   prefetchPages?: number,
+  readCachedPage?: (pageIndex: number) => T[] | undefined,
+  watchCachedPage?: (pageIndex: number, onChange: () => void) => () => void,
 }): {
   accumulated: T[],
   loadMore: () => void,
@@ -48,9 +75,14 @@ export function useAccumulatedPagination<T extends { id: string }>(options: {
   const {
     resetKey, pageData, pageIndex, setPageIndex, totalCount, loading,
     pageSize, prefetchPage, prefetchPages = DEFAULT_PREFETCH_PAGES,
+    readCachedPage, watchCachedPage,
   } = options
   const [accumulated, setAccumulated] = useState<T[]>([])
   const prevResetKeyRef = useRef(resetKey)
+  const cacheBacked = !!readCachedPage && !!watchCachedPage
+
+  const pageDataRef = useRef(pageData)
+  pageDataRef.current = pageData
 
   useEffect(() => {
     if (prevResetKeyRef.current !== resetKey) {
@@ -61,6 +93,27 @@ export function useAccumulatedPagination<T extends { id: string }>(options: {
   }, [resetKey, setPageIndex])
 
   useEffect(() => {
+    if (!cacheBacked || !readCachedPage || !watchCachedPage) return
+    const materialize = () => {
+      const pages: Array<T[] | undefined> = []
+      for (let p = 0; p <= pageIndex; p++) {
+        pages.push(readCachedPage(p) ?? (p === pageIndex ? pageDataRef.current : undefined))
+      }
+      const next = mergePagesById(pages)
+      setAccumulated(prev => (sameItems(prev, next) ? prev : next))
+    }
+    materialize()
+    const unsubscribes: Array<() => void> = []
+    for (let p = 0; p <= pageIndex; p++) {
+      unsubscribes.push(watchCachedPage(p, materialize))
+    }
+    return () => {
+      for (const unsubscribe of unsubscribes) unsubscribe()
+    }
+  }, [cacheBacked, readCachedPage, watchCachedPage, pageIndex])
+
+  useEffect(() => {
+    if (cacheBacked) return
     if (pageData === undefined || loading) return
     if (pageIndex === 0) {
       setAccumulated(prev => reconcileFirstPage(prev, pageData))
@@ -75,7 +128,7 @@ export function useAccumulatedPagination<T extends { id: string }>(options: {
       }
       return next
     })
-  }, [pageData, pageIndex, loading])
+  }, [cacheBacked, pageData, pageIndex, loading])
 
   const { lastAvailablePage, hasMore } = useMemo(
     () => computePaginationBounds({

--- a/web/pages/tasks/index.tsx
+++ b/web/pages/tasks/index.tsx
@@ -107,7 +107,7 @@ const TasksPage: NextPage = () => {
     [apiFilters, apiSorting, searchInput, selectedRootLocationIds, user?.id]
   )
 
-  const { data: tasksData, refetch, totalCount, loading: tasksLoading, prefetchPage } = useTasksPaginated(
+  const { data: tasksData, refetch, totalCount, loading: tasksLoading, prefetchPage, readCachedPage, watchCachedPage } = useTasksPaginated(
     !!selectedRootLocationIds && !!user
       ? { rootLocationIds: selectedRootLocationIds, assigneeId: user?.id }
       : undefined,
@@ -128,6 +128,8 @@ const TasksPage: NextPage = () => {
     loading: tasksLoading,
     pageSize: LIST_PAGE_SIZE,
     prefetchPage,
+    readCachedPage,
+    watchCachedPage,
   })
 
   const taskId = router.query['taskId'] as string | undefined

--- a/web/pages/view/[uid].tsx
+++ b/web/pages/view/[uid].tsx
@@ -268,7 +268,7 @@ function SavedTaskViewTab({
     [apiFilters, apiSorting, searchInput, rootIds, assigneeId]
   )
 
-  const { data: tasksData, refetch, totalCount, loading: tasksLoading, prefetchPage } = useTasksPaginated(
+  const { data: tasksData, refetch, totalCount, loading: tasksLoading, prefetchPage, readCachedPage, watchCachedPage } = useTasksPaginated(
     rootIds && assigneeId
       ? { rootLocationIds: rootIds, assigneeId }
       : undefined,
@@ -289,6 +289,8 @@ function SavedTaskViewTab({
     loading: tasksLoading,
     pageSize: LIST_PAGE_SIZE,
     prefetchPage,
+    readCachedPage,
+    watchCachedPage,
   })
 
   const tasks: TaskViewModel[] = useMemo(() => {


### PR DESCRIPTION
## Problem

Two issues in the patient and task lists:

1. **Edited rows show a refreshing spinner but keep rendering stale content.** For example, updating a patient's first name shows the loading indicator on the row but the table keeps displaying the old value.
2. **Inline-editable property cells that render chips are too tall**, making them the tallest cell in the row and inflating the overall row height.

## Root cause (stale rows)

`useAccumulatedPagination` stored materialized page **snapshots** in React state and only ever refreshed the **currently active page** (via `pageData`). As soon as you scroll/load more, the active page becomes the last one, so editing *any* row on an earlier page leaves its snapshot frozen — even though the normalized Apollo cache already holds the fresh value (mutation result + post-mutation reload all write to the cache). The spinner (driven by the refreshing-entities store) toggles correctly, but the displayed row never re-materializes.

## Fix

- `usePaginatedEntityQuery` now exposes `readCachedPage(pageIndex)` and `watchCachedPage(pageIndex, onChange)` backed by `cache.readQuery` / `cache.watch` (optimistic reads).
- `useAccumulatedPagination` uses these to **read every loaded page live from the Apollo cache** and re-materialize whenever any watched page changes. This means optimistic updates, mutation results, and post-mutation reloads are reflected on **all** rows, not just the active page. A referential-equality guard avoids needless re-renders, and the merge/dedup logic is extracted into a pure `mergePagesById` helper with unit tests.
- The previous snapshot path is retained as a fallback when cache helpers aren't provided.

Wired through all three callers: `PatientList`, `pages/tasks/index.tsx`, `pages/view/[uid].tsx`.

## Fix (chip height)

- `PropertyCell` chips (checkbox / select / multi-select) now use `size="sm"` (h-8) instead of the default `md` (h-10).
- `EditablePropertyCell` trigger padding reduced from `p-2` to `px-2 py-1`.

Together these keep chip cells from being the tallest cell in a row.

## Validation

- `npm run lint` (tsc + eslint) — passes
- `npm run test` (vitest) — 59 passed, including new `mergePagesById` cases

https://claude.ai/code/session_01Aj32axoUYxSP6oVsShajet

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aj32axoUYxSP6oVsShajet)_