### PR TITLE
Make user property select compact and print-friendly

### DIFF
--- a/web/components/properties/EditablePropertyCell.tsx
+++ b/web/components/properties/EditablePropertyCell.tsx
@@ -208,6 +208,7 @@ export function EditablePropertyCell({
           value={assigneeValue}
           allowTeams={true}
           allowUnassigned={true}
+          size="sm"
           onValueChanged={(next) => {
             const prev = assigneeValue
             if (next === prev) {

--- a/web/components/tasks/AssigneeSelect.tsx
+++ b/web/components/tasks/AssigneeSelect.tsx
@@ -19,6 +19,8 @@ interface AssigneeSelectProps {
   onMultiUserIdsSelected?: (userIds: string[]) => void,
   id?: string,
   className?: string,
+  /** Controls the height of the trigger. Use 'sm' for inline/in-table usage to keep row height compact. */
+  size?: 'md' | 'sm',
   [key: string]: unknown,
 }
 
@@ -33,6 +35,7 @@ export const  AssigneeSelect = ({
   onMultiUserIdsSelected,
   id,
   className,
+  size = 'md',
 }: AssigneeSelectProps) => {
   const translation = useTasksTranslation()
   const [isOpen, setIsOpen] = useState(false)
@@ -88,9 +91,15 @@ export const  AssigneeSelect = ({
 
   return (
     <>
+      {/* When printing we only want the selected value, not the interactive selection UI. */}
+      <span className="hidden print:inline truncate">{selectedItem?.name ?? ''}</span>
       <div
         id={id}
-        className={clsx('flex-row-4 justify-between items-center input-element h-12 px-2 py-2 rounded-md w-full hover:cursor-pointer', className)}
+        className={clsx(
+          'flex-row-4 justify-between items-center input-element px-2 rounded-md w-full hover:cursor-pointer print:hidden',
+          size === 'sm' ? 'h-9 py-1' : 'h-12 py-2',
+          className
+        )}
 
         role="button"
         tabIndex={0}
@@ -135,7 +144,7 @@ export const  AssigneeSelect = ({
                     <Info className="size-4" />
                   </button>
                 )}
-                <ChevronDown className={clsx('size-6 ml-2 flex-shrink-0 transition-transform duration-200 text-description', isOpen && 'rotate-180')} />
+                <ChevronDown className={clsx('ml-2 flex-shrink-0 transition-transform duration-200 text-description', size === 'sm' ? 'size-5' : 'size-6', isOpen && 'rotate-180')} />
               </div>
             </>
           )}


### PR DESCRIPTION
## Summary

The user (assignee) property rendered inline in property table cells used the full-size `AssigneeSelect` trigger (`h-12`, 48px), which was noticeably taller than the other in-table edit triggers and inflated the row height. It also rendered the full interactive selection UI (input border, chevron, search/info icons) when the page was printed.

This PR:

- Adds a `size` prop (`'md' | 'sm'`, default `'md'`) to `AssigneeSelect`. The `'sm'` variant uses a reduced height (`h-9`/`py-1`) and a slightly smaller chevron so it fits compactly in a table row.
- Uses `size="sm"` for the user property in `EditablePropertyCell` so the cell no longer grows taller than its siblings.
- Makes the select print-friendly: the interactive trigger is now `print:hidden`, and a print-only element renders just the selected value (user/team name). When printing we now show the value only, not the selection control.

Existing call sites (task editor, task list, property entry) keep the default `'md'` size, so their appearance is unchanged.

## Testing

- `tsc --noEmit` passes
- `eslint` passes on the changed files

https://claude.ai/code/session_013HB9f77s8Af6JLQf6i6Mnt

---
_Generated by [Claude Code](https://claude.ai/code/session_013HB9f77s8Af6JLQf6i6Mnt)_