### PR TITLE
Fix state filter operators to properly handle negation

### DIFF
--- a/web/components/tables/PatientList.tsx
+++ b/web/components/tables/PatientList.tsx
@@ -348,9 +348,22 @@ export const PatientList = forwardRef<PatientListRef, PatientListProps>(({ initi
         : []
     if (raw.length === 0) return allPatientStates
     const allowed = new Set(allPatientStates as unknown as string[])
-    const filtered = raw.filter(s => allowed.has(s))
-    return filtered.length > 0 ? (filtered as PatientState[]) : allPatientStates
-  }, [apiFilters, allPatientStates])
+    const selected = raw.filter(s => allowed.has(s))
+    if (selected.length === 0) return allPatientStates
+    // The dedicated `states` query argument narrows which states are fetched, so
+    // it must honour the filter operator. For "does not contain"/"not equals"
+    // the selected states are the ones to exclude, not the ones to keep.
+    const operator = (filters.find(f => f.id === 'state')?.value as { operator?: string } | undefined)?.operator
+    const isNegated = operator === 'notContains' || operator === 'notEquals'
+    if (isNegated) {
+      const excluded = new Set(selected)
+      const remaining = (allPatientStates as unknown as string[]).filter(s => !excluded.has(s))
+      // If every state is excluded the API-level filter clause will still drop
+      // all rows; fall back to the full set so the `states` argument stays valid.
+      return remaining.length > 0 ? (remaining as PatientState[]) : allPatientStates
+    }
+    return selected as PatientState[]
+  }, [apiFilters, allPatientStates, filters])
 
   const searchInput = useMemo(
     () => (searchQuery

--- a/web/utils/tableStateToApi.ts
+++ b/web/utils/tableStateToApi.ts
@@ -60,7 +60,7 @@ const TABLE_OPERATOR_TO_QUERY: Record<DataType, Partial<Record<HightideFilterOpe
     equals: QueryOperator.Eq,
     notEquals: QueryOperator.Neq,
     contains: QueryOperator.In,
-    notContains: QueryOperator.Neq,
+    notContains: QueryOperator.NotIn,
     isNotUndefined: QueryOperator.IsNotNull,
     isUndefined: QueryOperator.IsNull,
   },

--- a/web/utils/virtualDerivedTableState.test.ts
+++ b/web/utils/virtualDerivedTableState.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import type { ColumnFiltersState } from '@tanstack/react-table'
+import type { PatientViewModel } from '@/components/tables/PatientList'
+import { applyVirtualDerivedPatients } from '@/utils/virtualDerivedTableState'
+
+function patient(id: string, state: string): PatientViewModel {
+  return {
+    id,
+    name: id,
+    firstname: id,
+    lastname: id,
+    clinic: null,
+    birthdate: new Date('2000-01-01'),
+    sex: 'UNKNOWN',
+    state,
+    position: null,
+    openTasksCount: 0,
+    closedTasksCount: 0,
+    tasks: [],
+    properties: [],
+  } as unknown as PatientViewModel
+}
+
+function stateFilter(operator: string, tags: string[]): ColumnFiltersState {
+  return [
+    {
+      id: 'state',
+      value: {
+        operator,
+        dataType: 'singleTag',
+        parameter: { searchTags: tags },
+      },
+    },
+  ] as unknown as ColumnFiltersState
+}
+
+const patients = [
+  patient('a', 'ADMITTED'),
+  patient('b', 'WAIT'),
+  patient('c', 'DISCHARGED'),
+  patient('d', 'DEAD'),
+]
+
+describe('applyVirtualDerivedPatients - state filter', () => {
+  it('"contains" keeps only the selected states', () => {
+    const result = applyVirtualDerivedPatients(
+      patients,
+      stateFilter('contains', ['DISCHARGED', 'DEAD']),
+      [],
+      ''
+    )
+    expect(result.map(p => p.state).sort()).toEqual(['DEAD', 'DISCHARGED'])
+  })
+
+  it('"does not contain" excludes the selected states (issue #227)', () => {
+    const result = applyVirtualDerivedPatients(
+      patients,
+      stateFilter('notContains', ['DISCHARGED', 'DEAD']),
+      [],
+      ''
+    )
+    expect(result.map(p => p.state).sort()).toEqual(['ADMITTED', 'WAIT'])
+  })
+
+  it('"equals" keeps the single selected state', () => {
+    const result = applyVirtualDerivedPatients(
+      patients,
+      stateFilter('equals', ['ADMITTED']),
+      [],
+      ''
+    )
+    expect(result.map(p => p.state)).toEqual(['ADMITTED'])
+  })
+
+  it('"not equals" excludes the single selected state', () => {
+    const result = applyVirtualDerivedPatients(
+      patients,
+      stateFilter('notEquals', ['ADMITTED']),
+      [],
+      ''
+    )
+    expect(result.map(p => p.state).sort()).toEqual(['DEAD', 'DISCHARGED', 'WAIT'])
+  })
+
+  it('an empty selection does not filter anything out', () => {
+    const result = applyVirtualDerivedPatients(
+      patients,
+      stateFilter('notContains', []),
+      [],
+      ''
+    )
+    expect(result).toHaveLength(4)
+  })
+})

--- a/web/utils/virtualDerivedTableState.ts
+++ b/web/utils/virtualDerivedTableState.ts
@@ -159,14 +159,28 @@ function matchesBooleanOperator(done: boolean, operator: FilterOperator): boolea
   return true
 }
 
+// Selected tags of a singleTag/multiTag filter can be stored under several
+// parameter fields depending on how the filter UI serialized them. Mirror the
+// extraction used when building API filter clauses (see tableStateToApi.ts) so
+// the in-memory matcher considers the same values.
+function extractSelectedTags(parameter: FilterValue['parameter']): string[] {
+  const p = parameter as Record<string, unknown>
+  for (const field of ['uuidValues', 'searchTags', 'searchTagsContains']) {
+    const v = p[field]
+    if (Array.isArray(v) && v.length > 0) return v.map(String)
+  }
+  if (p['searchTag'] != null) return [String(p['searchTag'])]
+  if (parameter.stringValue) return [String(parameter.stringValue)]
+  return []
+}
+
 function matchesSingleTagOperator(
   value: string | undefined,
   operator: FilterOperator,
   fv: FilterValue
 ): boolean {
-  const p = fv.parameter
-  const tags = (p as { uuidValues?: unknown[], stringValue?: string }).uuidValues as string[] | undefined
-  const single = p.stringValue ?? (tags?.length === 1 ? tags[0] : undefined)
+  const tags = extractSelectedTags(fv.parameter)
+  const single = fv.parameter.stringValue ?? (tags.length === 1 ? tags[0] : undefined)
   const v = value ?? ''
   switch (operator) {
   case 'equals':
@@ -174,9 +188,9 @@ function matchesSingleTagOperator(
   case 'notEquals':
     return v !== single
   case 'contains':
-    return tags != null && tags.includes(v)
+    return tags.includes(v)
   case 'notContains':
-    return tags == null || !tags.includes(v)
+    return !tags.includes(v)
   case 'isUndefined':
     return v === ''
   case 'isNotUndefined':
@@ -245,11 +259,24 @@ function patientMatchesColumnFilter(patient: PatientViewModel, filter: ColumnFil
     return matchesTextOperator(patient.name, op, fv.parameter.stringValue ?? '')
   }
   if (id === 'state') {
-    const p = fv.parameter
-    const raw = p.uuidValues?.length ? p.uuidValues : p.stringValue ? [p.stringValue] : []
-    const tags = raw.map(String)
-    if (tags.length === 0) return true
-    return tags.includes(patient.state)
+    const tags = extractSelectedTags(fv.parameter)
+    const state = String(patient.state ?? '')
+    switch (op) {
+    case 'contains':
+      return tags.length === 0 || tags.includes(state)
+    case 'notContains':
+      return tags.length === 0 || !tags.includes(state)
+    case 'equals':
+      return tags.length === 0 || (tags.length === 1 && tags[0] === state)
+    case 'notEquals':
+      return tags.length === 0 || tags[0] !== state
+    case 'isUndefined':
+      return state === ''
+    case 'isNotUndefined':
+      return state !== ''
+    default:
+      return true
+    }
   }
   if (id === 'sex') {
     return matchesSingleTagOperator(patient.sex, op, fv)


### PR DESCRIPTION
Closes #227 

## Summary
This PR fixes the handling of negated state filters ("does not contain" and "not equals") in the patient list table. Previously, these operators were not correctly implemented, causing incorrect filtering behavior both in the UI and API queries.

## Key Changes

- **Added comprehensive test coverage** for state filter operators in `virtualDerivedTableState.test.ts`, covering `contains`, `notContains`, `equals`, `notEquals`, and empty selection cases

- **Refactored tag extraction logic** in `virtualDerivedTableState.ts`:
  - Created `extractSelectedTags()` helper function to consistently extract selected tags from various parameter field formats (`uuidValues`, `searchTags`, `searchTagsContains`, `searchTag`, `stringValue`)
  - This mirrors the extraction logic used in `tableStateToApi.ts` to ensure consistency between in-memory and API filtering

- **Fixed state filter matching** in `patientMatchesColumnFilter()`:
  - Replaced simple inclusion check with proper operator-aware logic
  - Now correctly handles all operators: `contains`, `notContains`, `equals`, `notEquals`, `isUndefined`, `isNotUndefined`
  - Empty selections now correctly return all patients (no filtering)

- **Fixed API query operator mapping** in `tableStateToApi.ts`:
  - Changed `notContains` operator mapping from `QueryOperator.Neq` to `QueryOperator.NotIn` to properly exclude multiple values

- **Fixed state query parameter generation** in `PatientList.tsx`:
  - Updated `statesToFetch` computation to respect filter operators
  - For negated operators (`notContains`, `notEquals`), the `states` query parameter now contains the states to *exclude* rather than include
  - Handles edge case where all states would be excluded by falling back to the full state set

## Implementation Details

The fix ensures that negated filters work correctly at both the in-memory filtering level (for virtual table rendering) and the API query level (for server-side data fetching). The `states` query parameter is now intelligently computed based on the filter operator to minimize data transfer while maintaining correct filtering semantics.

https://claude.ai/code/session_01B2howVipCwtfqWeuTkeFus