### PR TITLE
fix: widen table columns for chips and prevent print overflow

### DIFF
--- a/web/components/properties/EditablePropertyCell.tsx
+++ b/web/components/properties/EditablePropertyCell.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react'
+import clsx from 'clsx'
 import { Edit2 } from 'lucide-react'
 import { FieldType, type PropertyDefinitionType, type PropertyValueInput, type PropertyValueType } from '@/api/gql/generated'
 import { PropertyCell } from '@/components/properties/PropertyCell'
@@ -45,10 +46,19 @@ function wrapTrigger(node: ReactNode): ReactNode {
   )
 }
 
+function isChipFieldType(fieldType: FieldType): boolean {
+  return (
+    fieldType === FieldType.FieldTypeSelect ||
+    fieldType === FieldType.FieldTypeMultiSelect ||
+    fieldType === FieldType.FieldTypeCheckbox
+  )
+}
+
 function EditablePropertyTriggerDisplay({ property, fieldType }: { property: PropertyValueType | undefined, fieldType: FieldType }) {
+  const chipField = isChipFieldType(fieldType)
   return (
     <>
-      <div className="min-w-0 flex-1 overflow-hidden text-left">
+      <div className={clsx('text-left', chipField ? 'flex w-max max-w-none' : 'min-w-0 flex-1 overflow-hidden')}>
         <PropertyCell property={property} fieldType={fieldType} />
       </div>
       <Edit2 className="size-4 min-w-4 shrink-0 group-hover:block hidden print:hidden" />

--- a/web/components/properties/PropertyCell.tsx
+++ b/web/components/properties/PropertyCell.tsx
@@ -71,7 +71,7 @@ export const PropertyCell = ({
       ? property.definition.options[parseInt(selectOptionIndex, 10)]
       : property.selectValue
     return (
-      <div className="flex flex-wrap gap-1">
+      <div className="flex flex-nowrap gap-1 w-max max-w-none">
         <Chip size="sm" className="primary coloring-tonal">
           {selectOptionName}
         </Chip>
@@ -83,7 +83,7 @@ export const PropertyCell = ({
       return <FillerCell />
     }
     return (
-      <div className="flex flex-wrap gap-1">
+      <div className="flex flex-nowrap gap-1 w-max max-w-none">
         {property.multiSelectValues.map((val) => {
           const multiSelectOptionIndex = val.match(/-opt-(\d+)$/)?.[1]
           const multiSelectOptionName = multiSelectOptionIndex !== undefined && property.definition?.options

--- a/web/style/table-printing.css
+++ b/web/style/table-printing.css
@@ -62,7 +62,7 @@
     margin: 0 !important;
     padding: 0 !important;
 
-    @apply !text-sm;
+    @apply !text-xs;
     page-break-inside: auto;
 
     table-layout: fixed !important;
@@ -86,7 +86,7 @@
     color: black !important;
     background-color: white !important;
     border-color: black !important;
-    @apply !text-sm;
+    @apply !text-xs;
     overflow: visible !important;
     white-space: pre-wrap !important;
     word-break: break-word !important;
@@ -103,7 +103,7 @@
     text-align: left;
     font-weight: bold;
 
-    padding: 0.25rem 0.3rem !important;
+    padding: 0.2rem 0.25rem !important;
     border: 1px solid black !important;
     border-radius: 0 !important;
 
@@ -120,14 +120,33 @@
   .print-content tbody tr td {
     max-width: 100% !important;
 
-    @apply !text-sm;
+    @apply !text-xs;
     text-align: left;
     hyphens: auto;
 
-    padding: 0.2rem 0.3rem !important;
+    padding: 0.15rem 0.25rem !important;
     border: 1px solid black !important;
     border-radius: 0 !important;
 
+    background: white !important;
+    color: black !important;
+  }
+
+  .print-content tbody tr td div:has([data-name="chip"]) {
+    display: flex !important;
+    flex-wrap: wrap !important;
+    width: auto !important;
+    max-width: 100% !important;
+    min-width: 0 !important;
+  }
+
+  .print-content tbody tr td [data-name="chip"] {
+    display: inline-flex !important;
+    height: auto !important;
+    min-height: 0 !important;
+    max-width: 100% !important;
+    padding: 0 0.15rem !important;
+    white-space: normal !important;
     background: white !important;
     color: black !important;
   }


### PR DESCRIPTION
## Summary

Follow-up to the table/printing work. Two fixes:

### 1. Chips widen the column instead of wrapping
When select / multi-select property values produced several chips, they wrapped onto multiple rows inside the cell. They now stay on a single line and the column auto-grows (the table is `hw-autosize-table` with `overflow-x` scroll), so the column just gets wider instead.

- `PropertyCell`: select & multi-select chip lists use `flex-nowrap w-max` instead of `flex-wrap`.
- `EditablePropertyCell`: chip-type fields (select / multi-select / checkbox) no longer get the `min-w-0 overflow-hidden` shrink/clip wrapper that prevented the column from growing.

### 2. Printing: avoid text crossing table lines
The printed table is scaled down a bit and chips are forced to wrap/shrink within cell borders.

- Table/cell font reduced (`text-sm` → `text-xs`) with tighter padding so more fits.
- The screen no-wrap chip layout is reverted in print: chip containers wrap and chips get `height: auto` + `max-width: 100%`, so nothing overflows the cell borders.

## Testing
- `tsc --noEmit` and `eslint .` clean.
- `vitest run` — all 68 tests pass.
- Verified the rendered layout in a headless Chromium harness reproducing both table render paths (editable + non-editable):
  - **Screen**: chips stay on one line; column grows past the previous max width to fit them.
  - **Print**: chips wrap onto multiple lines and stay within the cell borders (no horizontal overflow).

https://claude.ai/code/session_011i1QbNhnRRGLUUADEyiDVw

---
_Generated by [Claude Code](https://claude.ai/code/session_011i1QbNhnRRGLUUADEyiDVw)_