### PR TITLE
Fix card title overflow (container queries) + persist card/table toggle per view

### DIFF
--- a/web/components/tables/PatientList.tsx
+++ b/web/components/tables/PatientList.tsx
@@ -14,6 +14,8 @@ import { PatientStateChip } from '@/components/patients/PatientStateChip'
 import { getLocationNodesByKind, type LocationKindColumn } from '@/utils/location'
 import { useTasksTranslation } from '@/i18n/useTasksTranslation'
 import { useTasksContext } from '@/hooks/useTasksContext'
+import { buildListLayoutStorageKey, resolveListRouteId, useListLayoutPreference } from '@/hooks/useListLayoutPreference'
+import { useRouter } from 'next/router'
 import type { ColumnDef, ColumnFiltersState, ColumnOrderState, PaginationState, Row, SortingState, TableState, VisibilityState } from '@tanstack/table-core'
 import { getPropertyColumnsForEntity, type PropertyColumnValueChangedPayload } from '@/utils/propertyColumn'
 import { getPropertyColumnIds, useColumnVisibilityWithPropertyDefaults } from '@/hooks/usePropertyColumnVisibility'
@@ -159,15 +161,21 @@ export const PatientList = forwardRef<PatientListRef, PatientListProps>(({ initi
   const [isShowSorting, setIsShowSorting] = useState(false)
 
   const [fetchPageIndex, setFetchPageIndex] = useState(0)
-  const [listLayout, setListLayout] = useState<'table' | 'card'>(() => (
-    typeof window !== 'undefined' && window.matchMedia('(max-width: 768px)').matches ? 'card' : 'table'
-  ))
+  const router = useRouter()
+  const layoutStorageKey = useMemo(() => buildListLayoutStorageKey({
+    entity: 'patients',
+    // Embedded lists force their layout, so they should not read/write a preference.
+    disabled: embedded && !derivedVirtualMode,
+    pathname: router.pathname,
+    routeId: resolveListRouteId(router.query, savedViewId),
+  }), [embedded, derivedVirtualMode, savedViewId, router.pathname, router.query])
+  const [listLayout, setListLayout] = useListLayoutPreference(layoutStorageKey)
 
   useEffect(() => {
     if (embedded && !derivedVirtualMode) {
       setListLayout('table')
     }
-  }, [embedded, derivedVirtualMode])
+  }, [embedded, derivedVirtualMode, setListLayout])
 
   const showFullToolbar = !embedded || derivedVirtualMode
   const useEmbeddedNoop = embedded && !derivedVirtualMode

--- a/web/components/tables/TaskList.tsx
+++ b/web/components/tables/TaskList.tsx
@@ -38,6 +38,8 @@ import { AssigneeSelect } from '../tasks/AssigneeSelect'
 import { PropertyColumnHeader } from '@/components/properties/PropertyColumnHeader'
 import { ClearPropertyColumnDialog } from '@/components/properties/ClearPropertyColumnDialog'
 import { useTaskPropertyClearDialog } from '@/hooks/useTaskPropertyClearDialog'
+import { buildListLayoutStorageKey, resolveListRouteId, useListLayoutPreference } from '@/hooks/useListLayoutPreference'
+import { useRouter } from 'next/router'
 
 function taskListDataSyncKey(tasks: TaskViewModel[]): string {
   return tasks.map(t => `${t.id}:${t.done}:${t.updateDate.getTime()}`).join('\0')
@@ -131,9 +133,15 @@ export const TaskList = forwardRef<TaskListRef, TaskListProps>(({ tasks: initial
   )
 
   const [clientVisibleCount, setClientVisibleCount] = useState(LIST_PAGE_SIZE)
-  const [listLayout, setListLayout] = useState<'table' | 'card'>(() => (
-    typeof window !== 'undefined' && window.matchMedia('(max-width: 768px)').matches ? 'card' : 'table'
-  ))
+  const router = useRouter()
+  const layoutStorageKey = useMemo(() => buildListLayoutStorageKey({
+    entity: 'tasks',
+    // Embedded lists (dashboard, related panels) force their layout.
+    disabled: embedded,
+    pathname: router.pathname,
+    routeId: resolveListRouteId(router.query),
+  }), [embedded, router.pathname, router.query])
+  const [listLayout, setListLayout] = useListLayoutPreference(layoutStorageKey)
   const [internalSorting, setInternalSorting] = useState<SortingState>(() => [
     { id: 'done', desc: false },
     { id: 'dueDate', desc: false },
@@ -215,7 +223,7 @@ export const TaskList = forwardRef<TaskListRef, TaskListProps>(({ tasks: initial
     if (embedded) {
       setListLayout('table')
     }
-  }, [embedded])
+  }, [embedded, setListLayout])
 
   useEffect(() => {
     if (typeof window === 'undefined') return

--- a/web/components/tasks/TaskCardView.tsx
+++ b/web/components/tasks/TaskCardView.tsx
@@ -178,7 +178,7 @@ export const TaskCardView = ({ task, onToggleDone: _onToggleDone, onClick, showA
     <div
       onClick={onClick ? () => onClick(task) : undefined}
       className={clsx(
-        'border-2 p-4 rounded-lg text-left transition-colors',
+        '@container border-2 p-4 rounded-lg text-left transition-colors',
         'relative bg-surface-variant bg-on-surface-variant w-full h-full',
         isClickable ? 'cursor-pointer hover:border-primary' : 'cursor-default',
         borderColorClass,
@@ -196,8 +196,8 @@ export const TaskCardView = ({ task, onToggleDone: _onToggleDone, onClick, showA
       }}
     >
       <div className="flex flex-col gap-3 w-full min-w-0">
-        <div className="flex flex-col sm:flex-row sm:items-start gap-4 w-full min-w-0">
-          <div className="flex items-start gap-4 w-full min-w-0 sm:flex-1 sm:min-w-0">
+        <div className="flex flex-col @lg:flex-row @lg:items-start gap-4 w-full min-w-0">
+          <div className="flex items-start gap-4 w-full min-w-0 @lg:flex-1 @lg:min-w-0">
             <div onClick={(e) => e.stopPropagation()}>
               <Checkbox
                 value={displayDone}
@@ -206,8 +206,8 @@ export const TaskCardView = ({ task, onToggleDone: _onToggleDone, onClick, showA
               />
             </div>
             <div className="flex-1 min-w-0">
-              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-2 sm:flex-wrap min-w-0 mb-2">
-                <div className="flex items-center gap-2 min-w-0 w-full sm:flex-1 sm:w-auto">
+              <div className="flex flex-col gap-2 @lg:flex-row @lg:items-center @lg:justify-between @lg:gap-2 @lg:flex-wrap min-w-0 mb-2">
+                <div className="flex items-center gap-2 min-w-0 w-full @lg:flex-1 @lg:w-auto">
                   {(task as FlexibleTask).priority && (
                     <div
                       className={clsx(
@@ -226,9 +226,9 @@ export const TaskCardView = ({ task, onToggleDone: _onToggleDone, onClick, showA
                   </div>
                 </div>
                 {task.assigneeTeam && (
-                  <div className="flex items-center gap-1.5 text-sm text-description min-w-0 w-full sm:w-auto sm:shrink-0 sm:justify-end">
+                  <div className="flex items-center gap-1.5 text-sm text-description min-w-0 w-full @lg:w-auto @lg:shrink-0 @lg:justify-end">
                     <Users className="size-5 text-description shrink-0" />
-                    <span className="min-w-0 break-words sm:truncate sm:max-w-40">{task.assigneeTeam.title}</span>
+                    <span className="min-w-0 break-words @lg:truncate @lg:max-w-40">{task.assigneeTeam.title}</span>
                   </div>
                 )}
                 {!task.assigneeTeam && task.assignee && (
@@ -238,14 +238,14 @@ export const TaskCardView = ({ task, onToggleDone: _onToggleDone, onClick, showA
                       e.stopPropagation()
                       setSelectedUserId(task.assignee!.id)
                     }}
-                    className="flex items-center gap-1.5 text-sm text-description min-w-0 w-full sm:w-auto sm:shrink-0 sm:justify-end hover:opacity-75 transition-opacity text-left"
+                    className="flex items-center gap-1.5 text-sm text-description min-w-0 w-full @lg:w-auto @lg:shrink-0 @lg:justify-end hover:opacity-75 transition-opacity text-left"
                   >
                     <AvatarStatusComponent
                       size="sm"
                       isOnline={task.assignee?.isOnline ?? null}
                       image={assigneeImage}
                     />
-                    <span className="min-w-0 break-words sm:truncate sm:max-w-[150px]">{task.assignee.name}</span>
+                    <span className="min-w-0 break-words @lg:truncate @lg:max-w-[150px]">{task.assignee.name}</span>
                   </button>
                 )}
               </div>
@@ -256,8 +256,8 @@ export const TaskCardView = ({ task, onToggleDone: _onToggleDone, onClick, showA
               )}
             </div>
           </div>
-          <div className="shrink-0 flex flex-col gap-2 text-sm text-description pt-0.5 w-full pl-14 sm:pl-0 sm:items-end sm:w-auto sm:max-w-[min(100%,11rem)]">
-            <div className="flex flex-col gap-2 items-stretch sm:flex-row sm:flex-wrap sm:items-center sm:justify-end gap-x-3 gap-y-2">
+          <div className="shrink-0 flex flex-col gap-2 text-sm text-description pt-0.5 w-full pl-14 @lg:pl-0 @lg:items-end @lg:w-auto @lg:max-w-[min(100%,11rem)]">
+            <div className="flex flex-col gap-2 items-stretch @lg:flex-row @lg:flex-wrap @lg:items-center @lg:justify-end gap-x-3 gap-y-2">
               {(task as FlexibleTask).sourceTaskPresetId && (
                 <Tooltip tooltip={translation('taskFromPresetTooltip')} alignment="top">
                   <button

--- a/web/hooks/useListLayoutPreference.test.ts
+++ b/web/hooks/useListLayoutPreference.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildListLayoutStorageKey,
+  parseStoredLayout,
+  resolveListRouteId
+} from './useListLayoutPreference'
+
+describe('parseStoredLayout', () => {
+  it('accepts the two known layouts', () => {
+    expect(parseStoredLayout('table')).toBe('table')
+    expect(parseStoredLayout('card')).toBe('card')
+  })
+
+  it('rejects unknown, empty or missing values', () => {
+    expect(parseStoredLayout('grid')).toBeNull()
+    expect(parseStoredLayout('')).toBeNull()
+    expect(parseStoredLayout(null)).toBeNull()
+    expect(parseStoredLayout(undefined)).toBeNull()
+  })
+})
+
+describe('resolveListRouteId', () => {
+  it('prefers an explicit saved-view id', () => {
+    expect(resolveListRouteId({ uid: 'from-route' }, 'saved-view')).toBe('saved-view')
+  })
+
+  it('falls back to the uid then id route params', () => {
+    expect(resolveListRouteId({ uid: 'view-123' })).toBe('view-123')
+    expect(resolveListRouteId({ id: 'loc-7' })).toBe('loc-7')
+  })
+
+  it('uses a shared root bucket for plain routes', () => {
+    expect(resolveListRouteId({})).toBe('root')
+  })
+
+  it('ignores array-valued and empty params', () => {
+    expect(resolveListRouteId({ uid: [] as unknown as string[] })).toBe('root')
+    expect(resolveListRouteId({ uid: '' })).toBe('root')
+  })
+})
+
+describe('buildListLayoutStorageKey', () => {
+  it('namespaces the key by entity, route and view id', () => {
+    expect(buildListLayoutStorageKey({
+      entity: 'tasks',
+      disabled: false,
+      pathname: '/view/[uid]',
+      routeId: 'abc',
+    })).toBe('tasks:/view/[uid]:abc')
+
+    expect(buildListLayoutStorageKey({
+      entity: 'patients',
+      disabled: false,
+      pathname: '/patients',
+      routeId: 'root',
+    })).toBe('patients:/patients:root')
+  })
+
+  it('keeps tasks and patients on the same route distinct', () => {
+    const tasks = buildListLayoutStorageKey({ entity: 'tasks', disabled: false, pathname: '/', routeId: 'root' })
+    const patients = buildListLayoutStorageKey({ entity: 'patients', disabled: false, pathname: '/', routeId: 'root' })
+    expect(tasks).not.toBe(patients)
+  })
+
+  it('returns null when persistence is disabled (embedded lists)', () => {
+    expect(buildListLayoutStorageKey({
+      entity: 'tasks',
+      disabled: true,
+      pathname: '/',
+      routeId: 'root',
+    })).toBeNull()
+  })
+})

--- a/web/hooks/useListLayoutPreference.ts
+++ b/web/hooks/useListLayoutPreference.ts
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useState } from 'react'
+
+export type ListLayout = 'table' | 'card'
+
+export const LIST_LAYOUT_STORAGE_PREFIX = 'helpwave.tasks.listLayout:'
+
+export type ListLayoutEntity = 'tasks' | 'patients'
+
+/**
+ * Returns the default layout for a fresh device: cards on small (mobile)
+ * viewports, table on larger ones. Mirrors the previous inline behaviour.
+ */
+export const getDefaultListLayout = (): ListLayout => (
+  typeof window !== 'undefined' && window.matchMedia('(max-width: 768px)').matches ? 'card' : 'table'
+)
+
+/** Validates a raw localStorage value, returning null when it is not a known layout. */
+export const parseStoredLayout = (raw: string | null | undefined): ListLayout | null => (
+  raw === 'table' || raw === 'card' ? raw : null
+)
+
+/**
+ * Picks the identifier that distinguishes one view from another on the same
+ * route. Saved-view ids win, then dynamic route params (`uid`, `id`), falling
+ * back to a shared `root` bucket for plain routes like `/tasks`.
+ */
+export const resolveListRouteId = (
+  query: Record<string, string | string[] | undefined>,
+  preferred?: string
+): string => {
+  if (preferred) return preferred
+  const uid = query['uid']
+  if (typeof uid === 'string' && uid) return uid
+  const id = query['id']
+  if (typeof id === 'string' && id) return id
+  return 'root'
+}
+
+/**
+ * Builds the per-view/route storage key, or `null` when persistence is
+ * disabled (e.g. embedded lists whose layout is forced).
+ */
+export const buildListLayoutStorageKey = (params: {
+  entity: ListLayoutEntity,
+  disabled: boolean,
+  pathname: string,
+  routeId: string,
+}): string | null => {
+  if (params.disabled) return null
+  return `${params.entity}:${params.pathname}:${params.routeId}`
+}
+
+const readStoredLayout = (storageKey: string | null): ListLayout | null => {
+  if (!storageKey || typeof window === 'undefined') return null
+  try {
+    return parseStoredLayout(window.localStorage.getItem(LIST_LAYOUT_STORAGE_PREFIX + storageKey))
+  } catch {
+    // localStorage can be unavailable (privacy mode, quota) - fall back to default.
+    return null
+  }
+}
+
+/**
+ * Persists the table/card layout toggle per view/route on the current device.
+ *
+ * The `storageKey` should uniquely identify the list within its route (build it
+ * via {@link buildListLayoutStorageKey}). Pass `null` to disable persistence.
+ */
+export const useListLayoutPreference = (storageKey: string | null) => {
+  const [layout, setLayoutState] = useState<ListLayout>(getDefaultListLayout)
+
+  // Hydrate from localStorage on the client once the key is known. Done in an
+  // effect (not the initializer) to keep server/client first render identical.
+  useEffect(() => {
+    const stored = readStoredLayout(storageKey)
+    if (stored) {
+      setLayoutState(stored)
+    }
+  }, [storageKey])
+
+  const setLayout = useCallback((next: ListLayout) => {
+    setLayoutState(next)
+    if (storageKey && typeof window !== 'undefined') {
+      try {
+        window.localStorage.setItem(LIST_LAYOUT_STORAGE_PREFIX + storageKey, next)
+      } catch {
+        // Ignore write failures (e.g. storage disabled or quota exceeded).
+      }
+    }
+  }, [storageKey])
+
+  return [layout, setLayout] as const
+}


### PR DESCRIPTION
## Summary

Follow-up to #250. Two issues with the new multi-column card grid:

1. **Task card titles overflowed**, wrapping a single character per line (see before/after below). The card's internal layout used **viewport** breakpoints (`sm:`), so a card sitting in a narrow grid cell on a *wide* screen still forced the title to squeeze in beside the due-date/assignee column — collapsing it to a 1-char-wide vertical strip.
2. **The card/table toggle wasn't remembered** — it reset to a viewport default on every load.

## What changed

### 1. Container-query card layout (fixes the overflow)
`TaskCardView` now uses **CSS container queries** instead of viewport breakpoints, so its layout responds to the *card's own width*, not the screen:
- Root is marked `@container`; the internal `sm:*` layout classes became `@lg:*` (32rem threshold).
- **Below 32rem** (typical grid cell): the title takes the **full card width** on its own line, with the assignee and due-date stacked beneath it — no more per-character squeeze.
- **At/above 32rem** (wide cards, e.g. 1–2 column layouts): the familiar side-by-side layout returns.

This is robust everywhere `TaskCardView` is rendered (lists, panels) because it adapts to whatever width it's given — verified in the compiled CSS (`container-type:inline-size` + `@container (min-width:32rem)` with all `@lg:` utilities inside).

### 2. Persist the view toggle per view/route (localStorage)
New `useListLayoutPreference` hook persists the table/card choice in `localStorage`, **keyed per entity + route + view** (e.g. `tasks:/view/[uid]:<uid>`, `patients:/patients:root`). So the preference sticks per device, independently for each list and saved view. Embedded lists (dashboard, related panels) force their layout and opt out of persistence.

Key derivation and value parsing are extracted as pure helpers (`buildListLayoutStorageKey`, `resolveListRouteId`, `parseStoredLayout`) and **covered by unit tests**.

## Testing
- `tsc --noEmit` ✓ · `eslint .` ✓ (0 errors)
- `vitest run` ✓ — **77 tests pass**, incl. 9 new for the storage-key/parse helpers
- `check-translations` ✓ · `next build` ✓
- Verified the container-query CSS is actually emitted in the production build (`@container (min-width:32rem)` with `@lg:flex-row`, `@lg:flex-1`, etc.).

## Files
- `web/components/tasks/TaskCardView.tsx` — viewport → container-query layout
- `web/components/tables/TaskList.tsx`, `web/components/tables/PatientList.tsx` — wire up persisted toggle
- `web/hooks/useListLayoutPreference.ts` (+ `.test.ts`) — new hook & pure helpers

https://claude.ai/code/session_01CBNSkfF2ym8882cYBMAMKN

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBNSkfF2ym8882cYBMAMKN)_