### PR TITLE
fix(web): keep sidebar counts in sync and stop infinite scroll from collapsing pages

### DIFF
--- a/web/components/tables/PatientList.tsx
+++ b/web/components/tables/PatientList.tsx
@@ -398,14 +398,18 @@ export const PatientList = forwardRef<PatientListRef, PatientListProps>(({ initi
   )
 
   const lastTotalCountRef = useRef<number | undefined>(undefined)
-  const { data: patientsData, refetch, totalCount, loading: patientsLoading, prefetchPage, readCachedPage, watchCachedPage } = usePatientsPaginated(
-    {
+  const patientsQueryVariables = useMemo(
+    () => ({
       locationId: hasLocationFilter ? undefined : (locationId || undefined),
       rootLocationIds: hasLocationFilter || locationId
         ? undefined
         : (effectiveRootLocationIds && effectiveRootLocationIds.length > 0 ? effectiveRootLocationIds : undefined),
       states: patientStates,
-    },
+    }),
+    [hasLocationFilter, locationId, effectiveRootLocationIds, patientStates]
+  )
+  const { data: patientsData, refetch, totalCount, loading: patientsLoading, prefetchPage, readCachedPage, watchCachedPage } = usePatientsPaginated(
+    patientsQueryVariables,
     {
       pagination: apiPagination,
       sorts: apiSorting.length > 0 ? apiSorting : undefined,

--- a/web/data/subscriptions/handler.test.ts
+++ b/web/data/subscriptions/handler.test.ts
@@ -101,6 +101,30 @@ describe('reloadEntityAfterMutation', () => {
     expect(getRefreshingPatientIds().has('patient-1')).toBe(false)
   })
 
+  it('refetches the global data query so sidebar counts stay in sync', async () => {
+    const includedOperationNames: string[] = []
+    const client = {
+      query: vi.fn().mockResolvedValue({
+        data: { task: { __typename: 'TaskType', id: 'task-1', updateDate: '2026-01-02T00:00:00Z' } },
+      }),
+      cache: {
+        readQuery: vi.fn().mockReturnValue({ task: { updateDate: '2026-01-01T00:00:00Z' } }),
+        writeQuery: vi.fn(),
+      },
+      refetchQueries: vi.fn().mockImplementation((options: { include?: Array<{ definitions?: Array<{ name?: { value?: string } }> }> }) => {
+        for (const doc of options.include ?? []) {
+          const name = doc.definitions?.[0]?.name?.value
+          if (name) includedOperationNames.push(name)
+        }
+        return Promise.resolve([])
+      }),
+    } as unknown as ApolloClient
+
+    await reloadEntityAfterMutation(client, 'Task', 'task-1')
+
+    expect(includedOperationNames).toContain('GetGlobalData')
+  })
+
   it('releases the refreshing gate even when the reload fails', async () => {
     const client = {
       query: vi.fn().mockRejectedValue(new Error('network down')),

--- a/web/data/subscriptions/handler.ts
+++ b/web/data/subscriptions/handler.ts
@@ -1,5 +1,5 @@
 import type { ApolloClient } from '@apollo/client/core'
-import { GetTaskDocument, GetPatientDocument, GetTasksDocument, GetPatientsDocument } from '@/api/gql/generated'
+import { GetTaskDocument, GetPatientDocument, GetTasksDocument, GetPatientsDocument, GetGlobalDataDocument } from '@/api/gql/generated'
 import { getParsedDocument } from '../hooks/queryHelpers'
 import { hasPendingMutationForEntity } from '../mutations/queue'
 import {
@@ -199,7 +199,11 @@ export async function reloadEntityAfterMutation(
       { conflictStrategy: 'server-wins' }
     )
       .then(() => client.refetchQueries({
-        include: [getParsedDocument(GetTasksDocument), getParsedDocument(GetPatientsDocument)],
+        include: [
+          getParsedDocument(GetTasksDocument),
+          getParsedDocument(GetPatientsDocument),
+          getParsedDocument(GetGlobalDataDocument),
+        ],
       }))
       .catch(() => {})
       .finally(() => removeRefreshingTask(entityId))
@@ -214,7 +218,11 @@ export async function reloadEntityAfterMutation(
     { conflictStrategy: 'server-wins' }
   )
     .then(() => client.refetchQueries({
-      include: [getParsedDocument(GetPatientsDocument), getParsedDocument(GetTasksDocument)],
+      include: [
+        getParsedDocument(GetPatientsDocument),
+        getParsedDocument(GetTasksDocument),
+        getParsedDocument(GetGlobalDataDocument),
+      ],
     }))
     .catch(() => {})
     .finally(() => removeRefreshingPatient(entityId))

--- a/web/data/subscriptions/useApolloGlobalSubscriptions.ts
+++ b/web/data/subscriptions/useApolloGlobalSubscriptions.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react'
 import { parse } from 'graphql'
 import type { ApolloClient } from '@apollo/client/core'
-import { GetPatientsDocument, GetTasksDocument } from '@/api/gql/generated'
+import { GetGlobalDataDocument, GetPatientsDocument, GetTasksDocument } from '@/api/gql/generated'
 import { getParsedDocument } from '@/data/hooks/queryHelpers'
 import {
   mergeTaskUpdatedIntoCache,
@@ -104,7 +104,7 @@ export function useApolloGlobalSubscriptions(
               () => {}
             )
             await client.refetchQueries({
-              include: [getParsedDocument(GetPatientsDocument)],
+              include: [getParsedDocument(GetPatientsDocument), getParsedDocument(GetGlobalDataDocument)],
             })
           } finally {
             removeRefreshingTask(taskId)
@@ -137,7 +137,7 @@ export function useApolloGlobalSubscriptions(
               () => {}
             )
             await client.refetchQueries({
-              include: [getParsedDocument(GetTasksDocument)],
+              include: [getParsedDocument(GetTasksDocument), getParsedDocument(GetGlobalDataDocument)],
             })
           } finally {
             removeRefreshingPatient(patientId)
@@ -170,7 +170,7 @@ export function useApolloGlobalSubscriptions(
               () => {}
             )
             await client.refetchQueries({
-              include: [getParsedDocument(GetTasksDocument)],
+              include: [getParsedDocument(GetTasksDocument), getParsedDocument(GetGlobalDataDocument)],
             })
           } finally {
             removeRefreshingPatient(patientId)

--- a/web/hooks/useAccumulatedPagination.test.ts
+++ b/web/hooks/useAccumulatedPagination.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { computePaginationBounds, mergePagesById } from './useAccumulatedPagination'
+import { computePaginationBounds, materializePages, mergePagesById } from './useAccumulatedPagination'
 
 const PAGE_SIZE = 25
 
@@ -92,5 +92,41 @@ describe('mergePagesById', () => {
     const fresh = { id: 'a', name: 'new' }
     expect(mergePagesById([[stale]])[0]).toBe(stale)
     expect(mergePagesById([[fresh]])[0]).toBe(fresh)
+  })
+})
+
+describe('materializePages', () => {
+  it('keeps earlier pages when a later page is added (one continuous list)', () => {
+    const lastPages = new Map<number, Array<{ id: string }>>()
+    materializePages([[{ id: 'a' }, { id: 'b' }]], lastPages)
+    const merged = materializePages(
+      [[{ id: 'a' }, { id: 'b' }], [{ id: 'c' }]],
+      lastPages
+    )
+    expect(merged.map(x => x.id)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('does not drop an earlier page that momentarily reads as undefined', () => {
+    const lastPages = new Map<number, Array<{ id: string }>>()
+    // First materialization: both pages readable.
+    materializePages([[{ id: 'a' }, { id: 'b' }], [{ id: 'c' }]], lastPages)
+    // Page 0 is briefly unreadable (e.g. a refetch in flight) -> falls back.
+    const merged = materializePages([undefined, [{ id: 'c' }]], lastPages)
+    expect(merged.map(x => x.id)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('propagates genuine removals (a defined empty page is authoritative)', () => {
+    const lastPages = new Map<number, Array<{ id: string }>>()
+    materializePages([[{ id: 'a' }], [{ id: 'b' }]], lastPages)
+    // Page 1 is now genuinely empty -> drop it, and a later undefined read stays empty.
+    expect(materializePages([[{ id: 'a' }], []], lastPages).map(x => x.id)).toEqual(['a'])
+    expect(materializePages([[{ id: 'a' }], undefined], lastPages).map(x => x.id)).toEqual(['a'])
+  })
+
+  it('reflects updated items on an already-known page', () => {
+    const lastPages = new Map<number, Array<{ id: string, v: number }>>()
+    materializePages([[{ id: 'a', v: 1 }]], lastPages)
+    const merged = materializePages([[{ id: 'a', v: 2 }]], lastPages)
+    expect(merged).toEqual([{ id: 'a', v: 2 }])
   })
 })

--- a/web/hooks/useAccumulatedPagination.ts
+++ b/web/hooks/useAccumulatedPagination.ts
@@ -54,6 +54,33 @@ export function mergePagesById<T extends { id: string }>(
   return out
 }
 
+/**
+ * Merges the per-page reads into a single accumulated list while remembering the
+ * last non-empty result for each page in `lastPages`. A page that reads as
+ * `undefined` (momentarily unreadable, e.g. while a refetch is in flight) falls
+ * back to its previously known items instead of disappearing — this keeps
+ * infinite scroll as one continuous list rather than collapsing to the latest
+ * page. A defined-but-empty read is authoritative and clears the remembered
+ * page so genuine removals still propagate.
+ */
+export function materializePages<T extends { id: string }>(
+  rawReads: ReadonlyArray<readonly T[] | undefined>,
+  lastPages: Map<number, T[]>
+): T[] {
+  const pages: Array<readonly T[] | undefined> = rawReads.map((read, page) => {
+    if (read === undefined) {
+      return lastPages.get(page)
+    }
+    if (read.length > 0) {
+      lastPages.set(page, read as T[])
+    } else {
+      lastPages.delete(page)
+    }
+    return read
+  })
+  return mergePagesById(pages)
+}
+
 export function useAccumulatedPagination<T extends { id: string }>(options: {
   resetKey: string,
   pageData: T[] | undefined,
@@ -84,9 +111,17 @@ export function useAccumulatedPagination<T extends { id: string }>(options: {
   const pageDataRef = useRef(pageData)
   pageDataRef.current = pageData
 
+  // Remembers the last non-empty items materialized for each loaded page so that a
+  // transient cache miss (e.g. a page that is momentarily unreadable while a
+  // refetch is in flight) never drops already-loaded rows. Without this the
+  // accumulated list could collapse to just the current page, making infinite
+  // scroll look like it "turned the page" instead of appending to one list.
+  const lastPagesRef = useRef<Map<number, T[]>>(new Map())
+
   useEffect(() => {
     if (prevResetKeyRef.current !== resetKey) {
       prevResetKeyRef.current = resetKey
+      lastPagesRef.current.clear()
       setPageIndex(0)
       setAccumulated([])
     }
@@ -95,11 +130,11 @@ export function useAccumulatedPagination<T extends { id: string }>(options: {
   useEffect(() => {
     if (!cacheBacked || !readCachedPage || !watchCachedPage) return
     const materialize = () => {
-      const pages: Array<T[] | undefined> = []
+      const rawReads: Array<T[] | undefined> = []
       for (let p = 0; p <= pageIndex; p++) {
-        pages.push(readCachedPage(p) ?? (p === pageIndex ? pageDataRef.current : undefined))
+        rawReads.push(readCachedPage(p) ?? (p === pageIndex ? pageDataRef.current : undefined))
       }
-      const next = mergePagesById(pages)
+      const next = materializePages(rawReads, lastPagesRef.current)
       setAccumulated(prev => (sameItems(prev, next) ? prev : next))
     }
     materialize()

--- a/web/pages/tasks/index.tsx
+++ b/web/pages/tasks/index.tsx
@@ -107,10 +107,17 @@ const TasksPage: NextPage = () => {
     [apiFilters, apiSorting, searchInput, selectedRootLocationIds, user?.id]
   )
 
+  const tasksQueryVariables = useMemo(
+    () => (
+      !!selectedRootLocationIds && !!user
+        ? { rootLocationIds: selectedRootLocationIds, assigneeId: user?.id }
+        : undefined
+    ),
+    [selectedRootLocationIds, user]
+  )
+
   const { data: tasksData, refetch, totalCount, loading: tasksLoading, prefetchPage, readCachedPage, watchCachedPage } = useTasksPaginated(
-    !!selectedRootLocationIds && !!user
-      ? { rootLocationIds: selectedRootLocationIds, assigneeId: user?.id }
-      : undefined,
+    tasksQueryVariables,
     {
       pagination: apiPagination,
       sorts: apiSorting.length > 0 ? apiSorting : undefined,

--- a/web/pages/view/[uid].tsx
+++ b/web/pages/view/[uid].tsx
@@ -268,10 +268,17 @@ function SavedTaskViewTab({
     [apiFilters, apiSorting, searchInput, rootIds, assigneeId]
   )
 
+  const tasksQueryVariables = useMemo(
+    () => (
+      rootIds && assigneeId
+        ? { rootLocationIds: rootIds, assigneeId }
+        : undefined
+    ),
+    [rootIds, assigneeId]
+  )
+
   const { data: tasksData, refetch, totalCount, loading: tasksLoading, prefetchPage, readCachedPage, watchCachedPage } = useTasksPaginated(
-    rootIds && assigneeId
-      ? { rootLocationIds: rootIds, assigneeId }
-      : undefined,
+    tasksQueryVariables,
     {
       pagination: apiPagination,
       sorts: apiSorting.length > 0 ? apiSorting : undefined,


### PR DESCRIPTION
## What & why

Addresses two reported problems:

1. **Infinite scroll / auto-fetching** — when scrolling the patient (and task) lists, the list could "turn the page": already-loaded rows disappeared and only the latest page stayed visible, instead of growing into one continuous list.
2. **Sidebar numbers don't update** — the counts in the side navigation / page headers (my tasks, patients, and the teams/wards/clinics groups) went stale after live updates until a full reload.

## Changes

### Sidebar counts stay in sync
The side-nav counts come from the `GetGlobalData` query (`myTasksCount`, `totalPatientsCount`, teams/wards/clinics). The realtime subscription handlers and `reloadEntityAfterMutation` previously refetched only `GetTasks` / `GetPatients`, never `GetGlobalData` — so a task being completed elsewhere, or a patient being created/updated, never refreshed the sidebar numbers.

- `useApolloGlobalSubscriptions`: task / patient / patientCreated subscriptions now include `GetGlobalData` in their `refetchQueries`.
- `reloadEntityAfterMutation` (handler.ts): includes `GetGlobalData` for both task and patient reloads.

### Infinite scroll = one continuous list
The cache-backed accumulation rebuilt the visible list from per-page Apollo cache reads on every cache change. If an earlier page momentarily read as `undefined` (e.g. while a refetch was in flight), that page was silently dropped, collapsing the list to just the current page.

- `materializePages()` (new, pure + unit-tested) remembers the last non-empty items per page and falls back to them when a page reads as `undefined`. A *defined-but-empty* read is still authoritative, so genuine removals continue to propagate.

### Less churn / steadier auto-fetch
The paginated query variables were rebuilt inline on every render in the tasks page, view page and patient list. That gave the `readCachedPage` / `watchCachedPage` / `prefetchPage` callbacks a new identity each render, so the cache watchers re-subscribed and prefetch re-ran constantly.

- Memoized the query-variables objects in `pages/tasks/index.tsx`, `pages/view/[uid].tsx` and `components/tables/PatientList.tsx`.

## Tests
- `materializePages`: keeps earlier pages, recovers a transiently-undefined page, propagates genuine removals, reflects item updates.
- `reloadEntityAfterMutation`: asserts `GetGlobalData` is among the refetched queries.
- Full suite: 82 passing; `tsc --noEmit` and `eslint` clean.

## Note / follow-up
I reproduced the Apollo paging behaviour in isolation and confirmed pages are cached and read back correctly, so the accumulation fix is defensive hardening for the "page turned, old rows gone" symptom. I could **not** fully reproduce the exact `6 visible vs 12 in the header` discrepancy from the screen recording without the live backend — that specific gap may also involve a list-vs-count data mismatch (the list query uses an explicit `states` set while `GetGlobalData.patients` uses the backend default). If it persists after this change, a console/network capture (or the exact patient counts per state) for that view would let me pin it down.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G2KhUmgX37hQhvJzzb8wtr)_