### PR TITLE
test(e2e): add patient table scroll test with 77 patients

### DIFF
--- a/tests/e2e/patient-table.spec.ts
+++ b/tests/e2e/patient-table.spec.ts
@@ -1,0 +1,203 @@
+import { test, expect, type Page } from '@playwright/test'
+import { mockBackend, seedAuth, type PatientFixture } from './support/mockBackend'
+
+const BASE = process.env.E2E_BASE_URL || 'http://localhost:3000'
+
+const ROOT_LOCATIONS = [
+  { id: 'root-1', title: 'General Hospital', kind: 'CLINIC' },
+]
+
+const ALLERGY_DEF = { id: 'def-allergy', name: 'Allergy', fieldType: 'FIELD_TYPE_TEXT', options: [] }
+
+const PATIENT_COUNT = 77
+
+// LIST_PAGE_SIZE in web/utils/listPaging.ts. The list fetches one page at a
+// time and accumulates pages as the user scrolls, so 77 patients span four
+// pages (25 + 25 + 25 + 2).
+const PAGE_SIZE = 25
+
+const STATES = ['ADMITTED', 'DISCHARGED', 'DEAD', 'WAIT'] as const
+const SEXES = ['MALE', 'FEMALE', 'UNKNOWN'] as const
+const ALLERGIES = ['Penicillin', 'Latex', 'Peanuts', 'Pollen', 'None', 'Aspirin', 'Iodine']
+const FIRST_NAMES = [
+  'Alex', 'Bea', 'Cory', 'Dana', 'Eli', 'Fran', 'Gale', 'Hana', 'Ivo', 'Jules',
+  'Kai', 'Lou', 'Max', 'Noa', 'Ola', 'Pat', 'Quin', 'Remy', 'Sam', 'Tory',
+]
+
+/**
+ * Deterministic pseudo-random generator so the fixture (and therefore the test)
+ * is reproducible across runs while still spreading patients across different
+ * states, sexes, birthdates and property values.
+ */
+function makeRng(seed: number) {
+  let state = seed >>> 0
+  return () => {
+    // xorshift32
+    state ^= state << 13
+    state ^= state >>> 17
+    state ^= state << 5
+    state >>>= 0
+    return state / 0xffffffff
+  }
+}
+
+function generatePatients(count: number): PatientFixture[] {
+  const rng = makeRng(0xc0ffee)
+  const patients: PatientFixture[] = []
+  for (let i = 0; i < count; i++) {
+    const index = String(i + 1).padStart(2, '0')
+    const firstname = FIRST_NAMES[Math.floor(rng() * FIRST_NAMES.length)]!
+    // Unique surname per patient guarantees every visible row text is distinct,
+    // which is what lets the test assert "no duplicates" purely from the DOM.
+    const lastname = `Patient_${index}`
+    const year = 1940 + Math.floor(rng() * 70)
+    const month = String(1 + Math.floor(rng() * 12)).padStart(2, '0')
+    const day = String(1 + Math.floor(rng() * 28)).padStart(2, '0')
+    patients.push({
+      id: `patient-${index}`,
+      firstname,
+      lastname,
+      state: STATES[Math.floor(rng() * STATES.length)],
+      sex: SEXES[Math.floor(rng() * SEXES.length)],
+      birthdate: `${year}-${month}-${day}`,
+      updateDate: rng() > 0.5 ? `2026-0${1 + Math.floor(rng() * 6)}-15T10:00:00Z` : null,
+      properties: [
+        {
+          id: `prop-${index}`,
+          definitionId: 'def-allergy',
+          textValue: ALLERGIES[Math.floor(rng() * ALLERGIES.length)]!,
+        },
+      ],
+    })
+  }
+  return patients
+}
+
+const PATIENTS = generatePatients(PATIENT_COUNT)
+
+async function seedStoredSelection(page: Page, ids: string[]) {
+  await page.addInitScript((selected) => {
+    window.localStorage.setItem('selected-root-location-ids', JSON.stringify(selected))
+  }, ids)
+}
+
+const ROW_SELECTOR = 'tr[data-name="table-body-row"]'
+
+/** Text of the first (name) cell of every rendered data row, in DOM order. */
+async function visibleRowNames(page: Page): Promise<string[]> {
+  return page.$$eval(ROW_SELECTOR, (rows) =>
+    rows.map((row) => row.querySelector('td')?.textContent?.trim() ?? ''))
+}
+
+/**
+ * Scroll the list's scrollable container down by roughly one viewport. The
+ * patient list lives inside the main content area (`overflow-y-auto`), so we
+ * walk up from the table to the same scrollable ancestor the app's infinite
+ * scroll sentinel observes, mirroring `findScrollableAncestor` in the web app.
+ */
+async function scrollListStep(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const isScrollable = (el: Element) => {
+      const oy = getComputedStyle(el).overflowY
+      return oy === 'auto' || oy === 'scroll' || oy === 'overlay'
+    }
+    const table = document.querySelector('table[data-name="table"]')
+    let current: Element | null = table?.parentElement ?? null
+    let container: HTMLElement | null = null
+    while (current && current !== document.body && current !== document.documentElement) {
+      if (isScrollable(current) && current.scrollHeight > current.clientHeight) {
+        container = current as HTMLElement
+        break
+      }
+      current = current.parentElement
+    }
+    const target: HTMLElement | Element =
+      container ?? document.scrollingElement ?? document.documentElement
+    const step = Math.max(('clientHeight' in target ? target.clientHeight : 600) * 0.9, 400)
+    target.scrollTop += step
+  })
+}
+
+test.describe('patient table (patient list)', () => {
+  test('loads 77 patients and reaches all of them by scrolling, with no duplicate rows', async ({ page }) => {
+    await seedAuth(page)
+    await seedStoredSelection(page, ['root-1'])
+    await mockBackend(page, {
+      patients: PATIENTS,
+      propertyDefinitions: [ALLERGY_DEF],
+      rootLocations: ROOT_LOCATIONS,
+    })
+
+    // 1) Load the root location (dashboard) first — it must render without
+    //    crashing before we drill into the patient list.
+    await page.goto(`${BASE}/`)
+    await expect(page.locator('body')).toBeVisible()
+
+    // 2) Navigate to the patient list.
+    await page.goto(`${BASE}/patients`)
+
+    // The list renders paged (a multiple of the page size), not all 77 at once —
+    // proving the table genuinely loads incrementally rather than dumping the
+    // whole dataset. (The sentinel may have already pulled a page or two by the
+    // time we measure, so we only assert it is below the full total.)
+    await expect(page.locator(ROW_SELECTOR).first()).toBeVisible({ timeout: 20000 })
+    await expect.poll(() => page.locator(ROW_SELECTOR).count(), { timeout: 20000 })
+      .toBeGreaterThanOrEqual(1)
+    const initialCount = await page.locator(ROW_SELECTOR).count()
+    expect(initialCount).toBeLessThan(PATIENT_COUNT)
+    expect(initialCount % PAGE_SIZE).toBe(0)
+
+    // 3) Scroll down step by step, accumulating the unique patient names we see
+    //    and asserting that at no point does the DOM contain a duplicate row.
+    const seen = new Set<string>()
+    let stagnantSteps = 0
+    const MAX_STEPS = 40
+
+    for (let step = 0; step < MAX_STEPS; step++) {
+      const names = await visibleRowNames(page)
+
+      // No duplicates among the currently-rendered rows.
+      expect(new Set(names).size).toBe(names.length)
+
+      for (const name of names) seen.add(name)
+
+      if (seen.size >= PATIENT_COUNT) break
+
+      // Drive one scroll step. The infinite-scroll sentinel loads the next page
+      // as it nears the viewport; scrolling brings it into range.
+      await scrollListStep(page)
+
+      // Wait for the next page to land (row count grows past what we just saw).
+      let grew = false
+      try {
+        await expect
+          .poll(() => page.locator(ROW_SELECTOR).count(), { timeout: 4000, intervals: [150] })
+          .toBeGreaterThan(names.length)
+        grew = true
+      } catch {
+        grew = false
+      }
+
+      if (grew) {
+        stagnantSteps = 0
+      } else {
+        // Give a lagging page fetch a moment, then retry a couple of times
+        // before giving up — avoids ending early on a slow load.
+        stagnantSteps++
+        if (stagnantSteps >= 3) break
+        await page.waitForTimeout(500)
+      }
+    }
+
+    // 4) Final state: every one of the 77 patients was seen exactly once, and
+    //    the fully-loaded table holds exactly 77 unique rows.
+    expect(seen.size).toBe(PATIENT_COUNT)
+
+    const finalNames = await visibleRowNames(page)
+    expect(finalNames.length).toBe(PATIENT_COUNT)
+    expect(new Set(finalNames).size).toBe(PATIENT_COUNT)
+
+    // The "load more" affordance is gone once the last page is reached.
+    await expect(page.getByRole('button', { name: /load more/i })).toHaveCount(0)
+  })
+})

--- a/tests/e2e/support/mockBackend.ts
+++ b/tests/e2e/support/mockBackend.ts
@@ -223,13 +223,26 @@ export async function mockBackend(page: Page, options: MockOptions): Promise<Moc
       })
     }
 
-    case 'GetPatients':
+    case 'GetPatients': {
       if (options.patientsDelayMs) {
         await new Promise(r => setTimeout(r, options.patientsDelayMs))
       }
+      // Honour the `pagination` argument so infinite scroll behaves like the real
+      // backend: each page returns only its own slice while `patientsTotal`
+      // reports the full count. Omitting pagination (or a non-positive pageSize)
+      // returns the whole list, preserving the previous single-page behaviour.
+      const pagination = variables['pagination'] as { pageIndex?: number, pageSize?: number } | undefined
+      const total = patientList.length
+      let pageItems = patientList
+      if (pagination && typeof pagination.pageSize === 'number' && pagination.pageSize > 0) {
+        const pageIndex = typeof pagination.pageIndex === 'number' ? pagination.pageIndex : 0
+        const start = pageIndex * pagination.pageSize
+        pageItems = patientList.slice(start, start + pagination.pageSize)
+      }
       return respond(route, {
-        data: { patients: patientList, patientsTotal: patientList.length },
+        data: { patients: pageItems, patientsTotal: total },
       })
+    }
 
     case 'GetPatient': {
       const id = variables['id'] as string


### PR DESCRIPTION
Add an end-to-end test that loads the dashboard root and /patients with a
generated fixture of 77 patients (varied state, sex, birthdate and property
data), then scrolls the list step by step, counting rows and asserting there
are never duplicate rows until all 77 unique patients are reached.

Make the mock backend honour the GetPatients pagination argument so each page
returns only its slice while patientsTotal reports the full count, matching the
real backend and exercising the list's infinite-scroll accumulation.

https://claude.ai/code/session_01XUqhXSTuUaekyz7VDjpWcp