### PR TITLE
fix: stop inline assignee edit from checking tasks locally

### DIFF
--- a/web/components/tables/TaskList.tsx
+++ b/web/components/tables/TaskList.tsx
@@ -764,11 +764,6 @@ export const TaskList = forwardRef<TaskListRef, TaskListProps>(({ tasks: initial
             <AssigneeSelect
               value={row.original.assigneeTeam ? `team:${row.original.assigneeTeam.id}` : row.original.assignee?.id ?? ''}
               onValueChanged={(value) => {
-                setOptimisticUpdates(prev => {
-                  const map = new Map(prev)
-                  map.set(row.original.id, true)
-                  return map
-                })
                 let data: { assigneeIds: string[], assigneeTeamId: string | null } = { assigneeIds: [], assigneeTeamId: null }
                 if (!value) {
                   data = { assigneeIds: [], assigneeTeamId: null }
@@ -780,13 +775,6 @@ export const TaskList = forwardRef<TaskListRef, TaskListProps>(({ tasks: initial
                 }
                 updateTaskMutate({
                   variables: { id: row.original.id, data },
-                })
-              }}
-              onDialogClose={() => {
-                setOptimisticUpdates(prev => {
-                  const map = new Map(prev)
-                  map.set(row.original.id, true)
-                  return map
                 })
               }}
               allowTeams={true}


### PR DESCRIPTION
## Summary

Closes #276

The inline `AssigneeSelect` cell in the task list (`web/components/tables/TaskList.tsx`) reused the `optimisticUpdates` map when the assignee changed. That map stores each task's **`done`** state (`Map<string, boolean>`) and is applied to the row data as `{ ...task, done: optimisticDone }`. As a result, editing the assignee inline optimistically set `done: true`, so the task appeared checked/completed in the frontend — even though the backend was never changed.

This is purely a frontend display bug: the task is never actually completed on the server, only shown as checked locally.

## Change

Removed the erroneous optimistic `done` updates from the assignee cell's `onValueChanged` and `onDialogClose` handlers. Changing the assignee now only fires the `updateTask` mutation and no longer visually completes the task.

## Testing

- `tsc --noEmit` passes
- `eslint` passes on the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7Bjksr92VvB6dWQoJGZN9)_