### PR TITLE
User documentation (review feedback applied + extended)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ htmlcov/
 # profile pictures
 /web/profile/
 /profile/
+
+# __pycache__
+__pycache__/
+*/__pycache__/

--- a/docs/user-workflows.md
+++ b/docs/user-workflows.md
@@ -1,0 +1,174 @@
+# helpwave tasks – Benutzer-Workflows
+
+Kurzanleitung für typische Abläufe in der Web-Anwendung. Technische Details (URLs, Berechtigungen) können je nach Installation variieren.
+
+---
+
+## 1. Anmeldung (Login)
+
+1. Öffnen Sie die URL Ihrer helpwave-tasks-Instanz im Browser.
+2. Sie werden bei geschützten Seiten zur Anmeldung weitergeleitet (Identity Provider, z. B. Keycloak).
+3. Melden Sie sich mit den von Ihrer Organisation vorgegebenen Zugangsdaten an.
+4. Nach erfolgreicher Anmeldung gelangen Sie zurück in die App; eine Sitzung kann automatisch verlängert werden.
+
+---
+
+## 2. Standort(e) wählen (Root-Location)
+
+Viele Listen und Zähler beziehen sich auf die **gewählten Root-Standorte** (Klinik, Krankenhaus oder vergleichbare oberste Ebene in Ihrer Struktur).
+
+1. Nach dem Login erscheint – sobald Standorte für Sie hinterlegt sind – ggf. automatisch der **Standort-Dialog**, falls noch kein Standort gewählt ist.
+2. Über die **Schaltfläche in der Kopfzeile** (ab größeren Bildschirmen) oder im **Seitenmenü** (mobil unten) können Sie einen oder **mehrere** Root-Standorte auswählen oder ändern.
+3. Erst mit gewähltem Standort sind z. B. Dashboard-Zahlen, „Meine Aufgaben“ und Patientenlisten im erwarteten Umfang sinnvoll gefüllt.
+
+---
+
+## 3. Patient anlegen
+
+1. Gehen Sie zu **Patienten** (Seitenmenü oder Dashboard-Kachel).
+2. Klicken Sie auf **Patient hinzufügen** (Plus-Symbol in der Werkzeugleiste der Patientenliste).
+3. Im rechten Panel öffnet sich die Patientenmaske. Standardmäßig ist der Reiter **Stammdaten** aktiv.
+4. Pflichtangaben u. a.: Vor- und Nachname, Geburtsdatum, Geschlecht, **Klinik** (und je nach Prozess Station/Team/Position). Status (z. B. Wartend) ist wählbar.
+    1. Klinik entspricht der "zahlenden Fachabteilung" (z.B. Kardiologie, Intensivmedizin, etc.)
+    2. Station entspricht dem physischen Standort des Patienten
+    3. Team entspricht den beteiligten Behandlungsteams (z.B. Intensivmedizin, Herzchirurgie, etc.)
+5. Speichern Sie den Datensatz. Der Patient erscheint in der Patientenliste, sofern er zu Ihrem gewählten Standortkontext passt.
+
+---
+
+## 4. Eigenschaften (Properties) – zwei Ebenen
+
+### 4.1 Felddefinitionen anlegen (für Patient *und* Aufgabe)
+
+**Wo:** **Einstellungen** (Zahnrad) → unter **System** → **Eigenschaften** (Seite `/properties`).
+
+Hier legen Administratoren **Felder** fest: Name, Typ (Text, Zahl, Datum, Auswahl, Benutzer, …) und ob sie für **Patienten** oder **Aufgaben** gelten. Ohne aktive Definition erscheinen die Felder nicht in den Masken.
+
+### 4.2 Werte am Patienten pflegen
+
+**Wo:** Patientenliste → Patient öffnen → Reiter **Eigenschaften**.
+
+Dort werden die definierten Felder als **Werte** befüllt oder geändert. Änderungen werden mit dem Patienten gespeichert (über „Patient aktualisieren“ im Hintergrund).
+
+**Kurz:** Definitionen unter **Einstellungen → Eigenschaften**; Ausfüllen unter **Patient → Reiter Eigenschaften**.
+
+---
+
+## 5. Wo finden Sie Patienten?
+
+| Ort | Inhalt |
+|-----|--------|
+| **Patienten** (`/patients`) | Zentrale Patientenliste für Ihren **Root-Standort-Kontext**. |
+| **Dashboard** (`/`) | Kurzliste **Zuletzt bearbeitete Patienten**. |
+| **Standort-Seite** (`/location/…`) | Reiter **Patienten**: Patienten, die diesem Knoten (Station, Team, …) zugeordnet sind bzw. der Filterung entsprechen. |
+| **Gespeicherte Ansicht** (`/view/…`) | Wenn die Ansicht auf **Patienten** basiert: gefilterte Patientenliste nach den gespeicherten Kriterien. |
+
+Die sichtbaren Datensätze hängen von **Berechtigungen** und **gewähltem Standort** ab.
+
+---
+
+## 6. Patientenliste filtern und sortieren
+
+Auf der Seite **Patienten** (und in eingebetteten Listen mit voller Werkzeugleiste):
+
+1. **Suche:** Suchfeld über der Tabelle (Volltext, ggf. inkl. Eigenschaften je nach Backend-Konfiguration).
+2. **Filter:** Schaltfläche **Filter** öffnet die Filterleiste; Sie können mehrere Kriterien kombinieren (z. B. Status, Standort, Eigenschaftsfelder – je nach Angebot).
+3. **Sortierung:** Schaltfläche **Sortierung** – mehrere Sortierkriterien sind möglich.
+4. **Spalten:** Über den **Spalten-Schalter** blenden Sie Spalten ein oder aus (inkl. dynamischer Eigenschaftsspalten).
+
+**Karten- vs. Tabellenansicht:** Für die **Druckausgabe** wird bei Druck automatisch die **Tabellenansicht** verwendet (siehe Abschnitt Drucken).
+
+---
+
+## 7. Schnellzugriff: gespeicherte Ansichten erstellen und teilen
+
+### Ansicht speichern (Schnellzugriff in der Seitenleiste)
+
+1. **Patienten** oder **Meine Aufgaben:** Stellen Sie Filter, Sortierung, Suche und sichtbare Spalten wie gewünscht ein.
+2. Sobald sich die Ansicht von der Standardansicht unterscheidet, erscheint ein Menü zum **Speichern** der Ansicht (z. B. „Als neue Ansicht speichern“).
+3. Nach dem Speichern erscheint die Ansicht unter **Gespeicherte Ansichten** im **Seitenmenü**; von dort springen Sie direkt auf `/view/<id>`.
+
+**Verwaltung:** **Einstellungen** → **Ansichten** (`/settings/views`): Umbenennen, Duplizieren, Löschen, Link öffnen.
+
+### Link teilen
+
+1. Öffnen Sie die gewünschte gespeicherte Ansicht (aus der Seitenleiste oder Einstellungen).
+2. Klicken Sie auf das **Teilen-Symbol** in der Kopfzeile der Ansicht – der Link (`…/view/<id>`) wird in die Zwischenablage kopiert.
+3. Senden Sie den Link an Kolleginnen und Kollegen. **Hinweis:** Empfänger müssen angemeldet sein und dürfen die zugrunde liegenden Daten sehen. Ist die Ansicht fremd, kann sie ggf. nur **lesend** sein; mit **In meine Ansichten kopieren** lässt sich eine eigene Kopie anlegen.
+
+---
+
+## 8. Aufgaben erstellen
+
+**Voraussetzung:** In Ihrem aktuellen Standort-Kontext muss mindestens **ein Patient** vorhanden sein; andernfalls kann die Schaltfläche „Aufgabe hinzufügen“ in der Liste ausgegraut sein.
+
+**Möglichkeiten:**
+
+- **Aufgabenliste** (z. B. unter einem Standort oder „Meine Aufgaben“): **Plus-Symbol** „Aufgabe hinzufügen“ → rechtes Panel **Aufgabe erstellen**.
+- **Patient öffnen** → Reiter **Aufgaben** → dort neue Aufgabe anlegen (Patient ist bereits vorausgewählt).
+
+Im Formular: Titel, Beschreibung, Fälligkeit, Priorität, Patient (falls nicht fix), Zuweisung (siehe unten).
+
+---
+
+## 9. Aufgaben zuweisen
+
+Im **Aufgaben-Detail** (Erstellen oder Bearbeiten im rechten Panel):
+
+- Zuweisung an eine **Person** (Benutzer) und/oder ein **Team** – je nach Konfiguration und Maske.
+- Über Avatare oder Benutzernamen lassen sich zugewiesene Personen einsehen; in der Tabellenansicht gibt es ggf. eine Spalte für **Zuweisung** / Patient.
+
+Team-bezogene Listen (z. B. Team-Standort) zeigen Aufgaben entsprechend der Teamzuweisung; Schalter wie „Alle Aufgaben“ können die Sicht erweitern.
+
+---
+
+## 10. Aufgabenliste filtern und sortieren
+
+Auf **Meine Aufgaben** und in Listen mit voller Aufgaben-Werkzeugleiste:
+
+1. **Suche** über dem Tabellenbereich.
+2. **Filter** und **Sortierung** analog zur Patientenliste (mehrere Filter und Sortierkriterien möglich).
+3. **Spalten** über den Spalten-Schalter; **Eigenschaften von Aufgaben** erscheinen als Spalten, wenn sie in den **Einstellungen → Eigenschaften** für Aufgaben definiert sind.
+
+**Gespeicherte Ansicht:** Wenn Sie Filter/Sortierung speichern, können Sie dieselbe Konfiguration später über **Gespeicherte Ansichten** oder den **geteilten Link** wieder aufrufen.
+
+---
+
+## 11. Drucken (inkl. Microsoft Edge und Seitenverhältnis)
+
+Die Anwendung bringt **Druck-Styles** für **Patienten- und Aufgaben-Tabellen** mit:
+
+@00100200345 bitte prüfen ob das so korrekt ist.
+
+### Empfohlene Schritte (allgemein)
+
+1. Wechseln Sie bei Bedarf in die **Tabellenansicht** (bei Druck wird die Tabelle sowieso genutzt; Kartenansicht ist am Bildschirm für den Druck nicht maßgeblich).
+2. **Browser-Druckdialog** öffnen: Windows/Linux z. B. **Strg+P**, macOS **⌘+P**.
+3. Wählen Sie **Querformat / Landscape**.
+4. Papierformat **A4** (oder das Format, das zu Ihrem Drucker passt; bei Abweichung „An Seite anpassen“ prüfen).
+
+### Microsoft Edge – Größe und Verhältnis
+
+1. **Drucken** öffnen (Strg+P).
+2. Ziel: **Drucker** oder **Als PDF speichern**.
+3. Unter **Weitere Einstellungen** bzw. **Layout**:
+   - **Querformat** aktivieren (entspricht der App-Vorgabe A4 landscape).
+   - **Skalierung:** Zuerst **100 %**; wenn Spalten abgeschnitten werden, **Anpassen an druckbare Fläche** / **Ganze Seite** (Bezeichnung je nach Edge-Version) wählen und prüfen, ob die Tabelle vollständig sichtbar ist.
+4. **Ränder:** Falls der Rand zu schmal wirkt oder der Drucker nicht randlos kann, auf **Standardränder** wechseln.
+5. **Vorschau** prüfen, bevor Sie drucken oder als PDF speichern.
+
+Hinweis: Die genaue Benennung von Optionen („Skalierung“, „Seitenanpassung“) kann sich zwischen Edge-Versionen leicht unterscheiden; entscheidend ist **Querformat** und eine Skalierung, bei der die **gesamte Tabelle** in der Vorschau lesbar ist.
+
+---
+
+## Kurzüberblick Navigation
+
+| Bereich | Menü / URL |
+|---------|------------|
+| Dashboard | Start / `/` |
+| Meine Aufgaben | `/tasks` |
+| Patienten | `/patients` |
+| Standort / Team | Seitenleiste → Kliniken, Stationen, Teams → `/location/<id>` |
+| Eigenschaften (Definitionen) | Einstellungen → Eigenschaften → `/properties` |
+| Ansichten verwalten | Einstellungen → Ansichten → `/settings/views` |
+| Gespeicherte Ansicht öffnen | Seitenleiste **Gespeicherte Ansichten** → `/view/<id>` |

--- a/docs/user-workflows.md
+++ b/docs/user-workflows.md
@@ -48,7 +48,9 @@ Hier legen Administratoren **Felder** fest: Name, Typ (Text, Zahl, Datum, Auswah
 
 **Wo:** Patientenliste → Patient öffnen → Reiter **Eigenschaften**.
 
-Dort werden die definierten Felder als **Werte** befüllt oder geändert. Änderungen werden mit dem Patienten gespeichert (über „Patient aktualisieren“ im Hintergrund).
+Dort werden die definierten Felder als **Werte** befüllt oder geändert. Änderungen werden **automatisch** gespeichert (im Hintergrund über „Patient aktualisieren“); Sie müssen also nicht zusätzlich auf „Speichern“ klicken.
+
+> **Hinweis:** Aktuell müssen jedem Patienten die **Eigenschaften** noch einzeln zugefügt werden. Künftig wird es – je nach Wunsch Ihrer Institution – standardmäßig voreingestellte **Eigenschaften** geben, die beim Anlegen eines Patienten bereits automatisch mit angelegt werden.
 
 **Kurz:** Definitionen unter **Einstellungen → Eigenschaften**; Ausfüllen unter **Patient → Reiter Eigenschaften**.
 
@@ -61,7 +63,7 @@ Dort werden die definierten Felder als **Werte** befüllt oder geändert. Änder
 | **Patienten** (`/patients`) | Zentrale Patientenliste für Ihren **Root-Standort-Kontext**. |
 | **Dashboard** (`/`) | Kurzliste **Zuletzt bearbeitete Patienten**. |
 | **Standort-Seite** (`/location/…`) | Reiter **Patienten**: Patienten, die diesem Knoten (Station, Team, …) zugeordnet sind bzw. der Filterung entsprechen. |
-| **Gespeicherte Ansicht** (`/view/…`) | Wenn die Ansicht auf **Patienten** basiert: gefilterte Patientenliste nach den gespeicherten Kriterien. |
+| **Gespeicherte Ansicht / Schnellzugriff** (`/view/…`) | Von Ihnen individuell erstellte und ggf. innerhalb Ihrer Institution geteilte Listen. Sie basieren auf den **Patienten** und wurden nach Ihren Vorstellungen und Wünschen sortiert und gefiltert. |
 
 Die sichtbaren Datensätze hängen von **Berechtigungen** und **gewähltem Standort** ab.
 
@@ -136,9 +138,7 @@ Auf **Meine Aufgaben** und in Listen mit voller Aufgaben-Werkzeugleiste:
 
 ## 11. Drucken (inkl. Microsoft Edge und Seitenverhältnis)
 
-Die Anwendung bringt **Druck-Styles** für **Patienten- und Aufgaben-Tabellen** mit:
-
-@00100200345 bitte prüfen ob das so korrekt ist.
+Die Anwendung bringt eigene **Druck-Styles** für **Patienten- und Aufgaben-Tabellen** mit, sodass die Tabellen beim Drucken sauber im Querformat aufbereitet werden.
 
 ### Empfohlene Schritte (allgemein)
 
@@ -161,6 +161,40 @@ Hinweis: Die genaue Benennung von Optionen („Skalierung“, „Seitenanpassung
 
 ---
 
+## 12. Aufgaben bearbeiten und abschließen
+
+1. Öffnen Sie eine Aufgabe per Klick in einer Aufgabenliste oder über den Reiter **Aufgaben** eines Patienten – die Aufgabe öffnet sich im rechten Panel.
+2. Sie können Titel, Beschreibung, Fälligkeit, Priorität und Zuweisung jederzeit anpassen. Änderungen werden **automatisch** gespeichert.
+3. **Erledigt markieren:** Setzen Sie das **Häkchen** an der Aufgabe (in der Detailansicht oder direkt in der Spalte **Erledigt** der Tabellenansicht). Erledigte Aufgaben werden entsprechend gekennzeichnet und können über Filter ein- oder ausgeblendet werden.
+
+---
+
+## 13. Einstellungen: Sprache, Design und Profil
+
+**Wo:** **Einstellungen** (Zahnrad im Seitenmenü, Seite `/settings`).
+
+- **Sprache:** Die Oberfläche ist u. a. in **Deutsch, Englisch, Spanisch, Französisch, Niederländisch und Portugiesisch** verfügbar. Wählen Sie Ihre bevorzugte Sprache; die Umstellung erfolgt sofort.
+- **Design (Theme):** Wählen Sie zwischen **Hell**, **Dunkel** oder **System** (folgt der Einstellung Ihres Betriebssystems).
+- **Profilbild:** Laden Sie ein Profilbild hoch oder entfernen Sie es. Das Bild erscheint u. a. bei Zuweisungen und Avataren.
+- **Cache leeren:** Falls Daten veraltet erscheinen, können Sie den lokalen Zwischenspeicher leeren und sich neu anmelden.
+
+---
+
+## 14. Abmelden (Logout)
+
+1. Öffnen Sie die **Einstellungen** (Zahnrad).
+2. Wählen Sie **Abmelden**. Sie werden vom Identity Provider abgemeldet und zur Anmeldeseite zurückgeleitet.
+
+Hinweis: An gemeinsam genutzten Geräten sollten Sie sich nach der Nutzung immer abmelden.
+
+---
+
+## 15. Feedback geben
+
+Über **Einstellungen → Feedback** können Sie direkt aus der Anwendung Rückmeldungen, Wünsche oder Fehlermeldungen an das helpwave-Team senden. Beschreiben Sie Ihr Anliegen möglichst konkret (z. B. betroffene Seite und Schritte zur Reproduktion), damit es schnell bearbeitet werden kann.
+
+---
+
 ## Kurzüberblick Navigation
 
 | Bereich | Menü / URL |
@@ -172,3 +206,4 @@ Hinweis: Die genaue Benennung von Optionen („Skalierung“, „Seitenanpassung
 | Eigenschaften (Definitionen) | Einstellungen → Eigenschaften → `/properties` |
 | Ansichten verwalten | Einstellungen → Ansichten → `/settings/views` |
 | Gespeicherte Ansicht öffnen | Seitenleiste **Gespeicherte Ansichten** → `/view/<id>` |
+| Einstellungen (Sprache, Design, Profil, Feedback, Abmelden) | Seitenleiste → Zahnrad → `/settings` |


### PR DESCRIPTION
Follow-up to #191. Applies the review feedback from @00100200345 and extends the user documentation (`docs/user-workflows.md`).

## Review feedback applied
- **Section 4.2 (Eigenschaften):** Clarified that property values are saved **automatically** (no manual "save" needed).
- **Section 4.2:** Added the missing note that properties currently have to be added per patient, and will later be available as institution-specific presets created automatically when a patient is added.
- **Section 5 (Wo finden Sie Patienten?):** Improved the description of the **Gespeicherte Ansicht / Schnellzugriff** row, per the reviewer's suggested wording.
- **Section 11 (Drucken):** Removed the leftover reviewer mention/placeholder (reviewer confirmed the content is correct) and reworded the intro.

## Documentation extended
- **§12 Aufgaben bearbeiten und abschließen** – editing tasks and marking them done via the checkbox / "Erledigt" column.
- **§13 Einstellungen: Sprache, Design und Profil** – language switching (DE/EN/ES/FR/NL/PT), theme (hell/dunkel/system), profile picture, clear cache.
- **§14 Abmelden (Logout)**.
- **§15 Feedback geben** – sending feedback from within the app.
- Added an **Einstellungen** entry to the navigation overview table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013kyTRPDs9AaH5newZrsw7X)_