### PR TITLE
test(e2e): de-flake patient count infinite-scroll test (timeout-safe)

### DIFF
--- a/tests/e2e/patient-table.spec.ts
+++ b/tests/e2e/patient-table.spec.ts
@@ -136,6 +136,9 @@ async function scrollListStep(page: Page): Promise<void> {
 
 test.describe('patient table (patient list)', () => {
   test('loads 77 patients and reaches all of them by scrolling, with no duplicate rows', async ({ page }) => {
+    // Rendering 77 rows with their property columns and walking every page is
+    // legitimately heavy; give it headroom over the default 30s test timeout.
+    test.slow()
     await seedAuth(page)
     await seedStoredSelection(page, ['root-1'])
     await mockBackend(page, {
@@ -191,16 +194,17 @@ test.describe('patient table (patient list)', () => {
       const before = names.length
 
       // Production path: scroll the sentinel toward the viewport and let the
-      // observer pull the next page.
+      // observer pull the next page. Probe only briefly — the
+      // IntersectionObserver is unreliable under CI load, so we must not spend
+      // the per-step budget waiting on a tick that may never come.
       await scrollListStep(page)
-      if (await rowsGrewBeyond(page, before, 3000)) continue
+      if (await rowsGrewBeyond(page, before, 1000)) continue
 
       // Scrolling did not trigger a load. If no "Load more" button remains the
       // list is genuinely exhausted; otherwise click it to advance the page
       // deterministically and wait for the new rows to land.
       if (await loadMoreButton.count() === 0) break
       try {
-        await loadMoreButton.scrollIntoViewIfNeeded()
         await loadMoreButton.click()
       } catch {
         // The button can disappear if an in-flight scroll-triggered fetch
@@ -208,7 +212,9 @@ test.describe('patient table (patient list)', () => {
         // freshly rendered rows.
         continue
       }
-      await rowsGrewBeyond(page, before, 8000)
+      // A click must make progress; if it somehow doesn't, stop rather than
+      // burn the whole timeout so the shortfall surfaces at the assertion below.
+      if (!(await rowsGrewBeyond(page, before, 5000))) break
     }
 
     // 4) Final state: every one of the 77 patients was seen exactly once, and


### PR DESCRIPTION
## Summary

De-flakes the patient-count e2e test (`tests/e2e/patient-table.spec.ts` → *"loads 77 patients and reaches all of them by scrolling"*). **Supersedes #284**, which had the right idea but timed out in CI.

## Background: test or software?

It's the **test**, not the app. The original failure surfaced on the Dependabot `@playwright/test` bump (#226) — a dev-dependency bump touching **zero app code** — where the same test passed on `main` and 21 sibling e2e tests passed. The app is correct and even renders an explicit **"Load more"** button (`PatientList.tsx`) as a deterministic loader; the test relied solely on physical scrolling → `IntersectionObserver`, which misses ticks under CI load and stranded it at 75/77.

## What went wrong in #284

#284 added a "Load more" fallback (good) but kept a large per-step budget: a 3s scroll probe **plus** an 8s post-click wait. When the sentinel never fires in CI — the original failure mode — walking four pages cost ~44s and blew the **30s test timeout**, so Playwright tore the page down mid-`$$eval` (`Target page … has been closed`). The pages loaded fine; the loop was just too slow.

## Fix (this PR contains the full, corrected change)

- **Converge fast via the deterministic button:** scroll probe trimmed to **1s**, post-click wait to **5s**, so the loop advances in seconds instead of tens of seconds.
- **Fail fast, never hang:** if a "Load more" click ever fails to add rows, break out so the shortfall surfaces at the count assertion rather than burning the whole timeout.
- **Headroom for a heavy test:** `test.slow()` (×3 timeout) — rendering 77 rows with property columns is legitimately heavy.

Still exercises the real scroll/sentinel path first (and `continue`s when it works), so production behaviour stays covered. All assertions are unchanged: paged initial load, no duplicate rows at any point, exactly 77 unique rows at the end, and the "Load more" affordance gone once exhausted.

> Dependencies aren't installed in the authoring environment (network-restricted fresh clone), so the suite runs in CI rather than locally. The change uses only already-imported symbols and is type-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016PpNbGMvK4ekY3x42sJNFA)_