### PR TITLE
fix(locations): make root/location selection dialog mobile-safe (#271)

### DIFF
--- a/web/components/locations/LocationSelectionDialog.tsx
+++ b/web/components/locations/LocationSelectionDialog.tsx
@@ -462,11 +462,11 @@ export const LocationSelectionDialog = ({
         </div>
       )}
       description={descriptionTranslationMap[useCase]}
-      className="w-150 h-[80vh] flex flex-col max-w-full"
+      className="w-150 max-w-[calc(100vw-2rem)] h-[80vh] max-h-[calc(100vh-2rem)] flex flex-col"
     >
       <div className="flex flex-col gap-4 mt-4 h-full overflow-hidden">
-        <div className="flex items-center gap-2 flex-none">
-          <div className="flex-grow">
+        <div className="flex flex-wrap items-center gap-2 flex-none">
+          <div className="flex-grow min-w-[12rem]">
             <SearchBar
               placeholder={translation('searchLocations')}
               value={searchQuery}


### PR DESCRIPTION
## Problem

Closes #271 
On iPhone/Safari the "Standort auswählen" (root/location selection) dialog renders off-screen — the box is shifted left and its content is clipped (see #271).

![issue](https://github.com/user-attachments/assets/914f7975-7f3e-4165-9a58-0445c93d234a)

## Root cause

`LocationSelectionDialog` passed `max-w-full` to the hightide `Dialog`'s content box:

```tsx
className="w-150 h-[80vh] flex flex-col max-w-full"
```

hightide already constrains the dialog with a viewport-safe cap in its theme (component layer):

```css
[data-name="dialog-content"] { @apply ... max-w-[calc(100vw-2rem)] max-h-[calc(100vh-2rem)]; }
```

But `max-w-full` is a Tailwind **utility** (utilities layer), so it **overrides** that component-layer cap, changing the effective constraint to `max-width: 100%`.

The dialog content is `position: fixed` and centered via `left-1/2 -translate-x-1/2`. For a fixed element, `max-width: 100%` resolves against the **layout viewport**, which on iOS Safari is wider than the **visual viewport**. The centered box ends up wider than what's visible and overflows off-screen (clipped on the left). The `-2rem` margin baked into hightide's cap exists precisely to avoid this.

## Fix

- Replace `max-w-full` with the iOS-safe `max-w-[calc(100vw-2rem)]` and add a matching `max-h-[calc(100vh-2rem)]`, so the box always stays inside the visual viewport with a small margin.
- Let the header toolbar (search + expand/collapse/select-all icon groups) `flex-wrap` and give the search field a sensible `min-w`, so it never forces horizontal overflow on narrow screens.

No behavioural change on desktop (`w-150`/`h-[80vh]` still apply; the new caps only kick in below ~632px / on short viewports).

Verified `tsc --noEmit` and `eslint` pass on the changed file.

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pw4EWuEBrhHNnkAWuNXYw7)_