### PR TITLE
Show full text properties when printing tables

### DIFF
--- a/web/components/properties/PropertyCell.tsx
+++ b/web/components/properties/PropertyCell.tsx
@@ -102,9 +102,14 @@ export const PropertyCell = ({
       ? `${textValue.slice(0, textCellMaxLength)}...`
       : textValue
     return (
-      <Tooltip tooltip={displayValue}>
-        <span className="truncate block max-w-full overflow-hidden text-ellipsis">{displayValue}</span>
-      </Tooltip>
+      <>
+        {/* Screen: truncate to keep the table compact, full text available on hover. */}
+        <Tooltip tooltip={textValue} containerClassName="print:hidden">
+          <span className="truncate block max-w-full overflow-hidden text-ellipsis">{displayValue}</span>
+        </Tooltip>
+        {/* Print (Ctrl+P): show the full, untruncated text. */}
+        <span className="hidden print:block whitespace-pre-wrap break-words">{textValue}</span>
+      </>
     )
   }
   case FieldType.FieldTypeUser: {


### PR DESCRIPTION
Text properties are truncated to 32 characters in the table view to keep
the layout compact. When printing (Ctrl+P), render the full untruncated
text instead so notes and other long text are not cut off.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015Mm3KydMGUwNeP2uScKH92