### PR TITLE
fix(web): virtualized list scrolling, fill-height, and inline property edits

### DIFF
--- a/tests/e2e/patient-inline-edit.spec.ts
+++ b/tests/e2e/patient-inline-edit.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect, type Locator, type Page } from '@playwright/test'
+import { mockBackend, seedAuth, type PatientFixture } from './support/mockBackend'
+
+const BASE = process.env.E2E_BASE_URL || 'http://localhost:3000'
+
+const ROOT_LOCATIONS = [{ id: 'root-1', title: 'General Hospital', kind: 'CLINIC' }]
+const ALLERGY_DEF = { id: 'def-allergy', name: 'Allergy', fieldType: 'FIELD_TYPE_TEXT', options: [] }
+
+async function seedStoredSelection(page: Page, ids: string[]) {
+  await page.addInitScript((selected) => {
+    window.localStorage.setItem('selected-root-location-ids', JSON.stringify(selected))
+  }, ids)
+}
+
+function rowByLastName(page: Page, lastName: string): Locator {
+  return page.locator('tr[data-name="table-body-row"]').filter({ hasText: lastName })
+}
+
+function allergyCell(row: Locator): Locator {
+  return row.locator('[data-testid="editable-property-cell"][data-property-definition-id="def-allergy"]')
+}
+
+async function openEditor(page: Page, cell: Locator): Promise<Locator> {
+  await cell.getByRole('button').first().click()
+  const input = page.getByRole('textbox').last()
+  await expect(input).toBeVisible()
+  return input
+}
+
+async function commit(page: Page) {
+  await page.getByRole('button', { name: 'Done' }).click()
+}
+
+test.describe('patient inline property edit', () => {
+  test.beforeEach(async ({ page }) => {
+    await seedAuth(page)
+    await seedStoredSelection(page, ['root-1'])
+  })
+
+  test('setting a value on a previously empty property persists after the refetch', async ({ page }) => {
+    // Regression (videos): an inline edit was written to the backend but the
+    // list cell reverted to empty once the post-mutation refetch landed, because
+    // the cache merged the stale (empty) server snapshot back over the edit.
+    const handle = await mockBackend(page, {
+      patients: [{ id: 'p-1', firstname: 'Jane', lastname: 'Doe' }],
+      propertyDefinitions: [ALLERGY_DEF],
+      rootLocations: ROOT_LOCATIONS,
+    })
+
+    await page.goto(`${BASE}/patients`)
+    const row = rowByLastName(page, 'Doe')
+    await expect(row).toBeVisible({ timeout: 20000 })
+
+    const cell = allergyCell(row)
+    const input = await openEditor(page, cell)
+    await input.fill('Penicillin')
+    await commit(page)
+
+    // Optimistic value shows ...
+    await expect(cell).toContainText('Penicillin')
+
+    // ... and survives the UpdatePatient + refetch round-trip.
+    await page.waitForLoadState('networkidle')
+    await expect(cell).toContainText('Penicillin')
+
+    const update = handle.mutations.find(m => m.name === 'UpdatePatient')
+    expect(update?.variables['id']).toBe('p-1')
+  })
+
+  test('clearing a property removes it and it stays cleared after the refetch', async ({ page }) => {
+    // Regression (issue: empty selection / clearing): the cache policy unioned
+    // the previous and incoming property arrays, so a cleared property was
+    // re-added from the stale cache value and reappeared after the refetch.
+    await mockBackend(page, {
+      patients: [{
+        id: 'p-1',
+        firstname: 'Jane',
+        lastname: 'Doe',
+        properties: [{ id: 'prop-1', definitionId: 'def-allergy', textValue: 'Penicillin' }],
+      }],
+      propertyDefinitions: [ALLERGY_DEF],
+      rootLocations: ROOT_LOCATIONS,
+    })
+
+    await page.goto(`${BASE}/patients`)
+    const row = rowByLastName(page, 'Doe')
+    const cell = allergyCell(row)
+    await expect(cell).toContainText('Penicillin', { timeout: 20000 })
+
+    const input = await openEditor(page, cell)
+    await input.fill('')
+    await commit(page)
+
+    await page.waitForLoadState('networkidle')
+    await expect(cell).not.toContainText('Penicillin')
+  })
+})

--- a/tests/e2e/patient-table.spec.ts
+++ b/tests/e2e/patient-table.spec.ts
@@ -165,4 +165,52 @@ test.describe('patient table (patient list)', () => {
     expect(seen.size).toBe(PATIENT_COUNT)
     expect(maxRenderedRows).toBeLessThan(PATIENT_COUNT)
   })
+
+  test('scrolls inside the list container only — the page must not grow a second scrollbar', async ({ page }) => {
+    // Fixed 1280x720 viewport so the height maths is deterministic: 77 rows far
+    // exceed the viewport, so the list must scroll *inside* its own container.
+    await page.setViewportSize({ width: 1280, height: 720 })
+    await seedAuth(page)
+    await seedStoredSelection(page, ['root-1'])
+    await mockBackend(page, {
+      patients: PATIENTS,
+      propertyDefinitions: [ALLERGY_DEF],
+      rootLocations: ROOT_LOCATIONS,
+    })
+
+    await page.goto(`${BASE}/patients`)
+    await expect(page.locator(ROW_SELECTOR).first()).toBeVisible({ timeout: 20000 })
+    await expect.poll(() => page.locator(ROW_SELECTOR).count(), { timeout: 20000 })
+      .toBeGreaterThan(5)
+
+    const metrics = await page.evaluate(() => {
+      const isScrollable = (el: Element) => {
+        const oy = getComputedStyle(el).overflowY
+        return oy === 'auto' || oy === 'scroll' || oy === 'overlay'
+      }
+      const table = document.querySelector('table[data-name="table"]')
+      let current: Element | null = table?.parentElement ?? null
+      let inner: HTMLElement | null = null
+      while (current && current !== document.body) {
+        if (isScrollable(current) && current.scrollHeight > current.clientHeight) {
+          inner = current as HTMLElement
+          break
+        }
+        current = current.parentElement
+      }
+      const main = document.querySelector('main')
+      const outer = main?.parentElement ?? null
+      return {
+        innerScrolls: !!inner,
+        outerOverflow: outer ? outer.scrollHeight - outer.clientHeight : -1,
+      }
+    })
+
+    // The virtualized list has its own scroll container ...
+    expect(metrics.innerScrolls).toBe(true)
+    // ... and the surrounding page does not also overflow (no double scrollbar).
+    // Before the fix the list fell back to a fixed max-height and pushed the
+    // outer content area past the viewport, producing the second scrollbar.
+    expect(metrics.outerOverflow).toBeLessThan(32)
+  })
 })

--- a/web/api/mutations/patients/updatePatient.plan.list.integration.test.ts
+++ b/web/api/mutations/patients/updatePatient.plan.list.integration.test.ts
@@ -105,6 +105,29 @@ describe('updatePatientOptimisticPlan list integration', () => {
     expect(allergy?.definition?.name).toBe('Allergy')
   })
 
+  it('optimistically removes a list patient property when its value is cleared', () => {
+    const cache = new InMemoryCache(buildCacheConfig())
+    seedListPatient(cache)
+
+    // Clearing the only property sends an empty input set (see
+    // mergePropertyChangeIntoInputs), which must drop the property from the
+    // cached list immediately rather than re-adding it.
+    const variables = { id: 'p-1', data: { properties: [] } }
+    const [patch] = updatePatientOptimisticPlan.getPatches(variables)
+    patch!.apply(cache, variables)
+
+    const diff = cache.diff({
+      query: getParsedDocument(GetPatientsDocument),
+      variables: LIST_VARIABLES,
+      optimistic: true,
+      returnPartialData: true,
+    })
+    expect(diff.complete).toBe(true)
+
+    const patients = readListPatients(cache)
+    expect(patients?.[0]?.properties ?? []).toHaveLength(0)
+  })
+
   it('changes the paginated list item key so accumulated pagination detects the update', () => {
     const cache = new InMemoryCache(buildCacheConfig())
     seedListPatient(cache)

--- a/web/api/mutations/patients/updatePatient.plan.ts
+++ b/web/api/mutations/patients/updatePatient.plan.ts
@@ -7,7 +7,7 @@ import {
 import { getParsedDocument } from '@/data/hooks/queryHelpers'
 import { registerOptimisticPlan } from '@/data/mutations/registry'
 import type { OptimisticPlan, OptimisticPatch } from '@/data/mutations/types'
-import { buildOptimisticProperties, readEntityProperties, applyOptimisticPropertyScalars, getNewOptimisticProperties } from '@/api/mutations/shared/optimisticProperties'
+import { buildOptimisticProperties, readEntityProperties, applyOptimisticPropertyScalars, buildOptimisticPropertyRefs } from '@/api/mutations/shared/optimisticProperties'
 
 type UpdatePatientVariables = {
   id: string,
@@ -70,19 +70,14 @@ export const updatePatientOptimisticPlan: OptimisticPlan<UpdatePatientVariables>
             const existingProps = readEntityProperties(cache, 'PatientType', patientId)
             const optimisticProperties = buildOptimisticProperties(existingProps, data.properties, patientId)
             applyOptimisticPropertyScalars(cache, optimisticProperties)
-            const newProperties = getNewOptimisticProperties(optimisticProperties)
-            if (newProperties.length > 0) {
-              fields['properties'] = (existing, details) => {
-                const { toReference } = details as unknown as {
-                  toReference: (obj: unknown, mergeIntoStore?: boolean) => unknown,
-                }
-                const current = Array.isArray(existing) ? existing : []
-                const newRefs = newProperties.flatMap((property) => {
-                  const ref = toReference(property, true)
-                  return ref ? [ref] : []
-                })
-                return [...current, ...newRefs]
+            // Replace the whole `properties` list with the optimistic set so an
+            // edit that removes a property (e.g. clearing a select) is reflected
+            // immediately instead of lingering until the server refetch.
+            fields['properties'] = (_existing, details) => {
+              const { toReference } = details as unknown as {
+                toReference: (obj: unknown, mergeIntoStore?: boolean) => unknown,
               }
+              return buildOptimisticPropertyRefs(optimisticProperties, toReference)
             }
           }
           cache.modify({ id, fields })

--- a/web/api/mutations/shared/optimisticProperties.ts
+++ b/web/api/mutations/shared/optimisticProperties.ts
@@ -34,7 +34,11 @@ export type OptimisticPropertyValue = {
   selectValue?: string | null,
   multiSelectValues?: string[] | null,
   userValue?: string | null,
+  user?: unknown,
+  team?: unknown,
 }
+
+type ToReference = (object: unknown, mergeIntoStore?: boolean) => unknown
 
 const fragmentCache = new Map<string, { document: DocumentNode, name: string }>()
 
@@ -136,6 +140,13 @@ export function buildOptimisticProperties(
       id: `attachment-${entityId}-${inp.definitionId}`,
       definition: { __ref: `PropertyDefinitionType:${inp.definitionId}` },
       ...scalars,
+      // Include the nullable `user`/`team` selections so the optimistic entity
+      // is a *complete* read for the list/detail queries. An incomplete read
+      // makes the active cache-and-network queries revalidate over the network
+      // before the mutation commits, and that stale response overwrites the
+      // optimistic value — so the edit appears to vanish until a full reload.
+      user: null,
+      team: null,
     }
   })
 }
@@ -148,6 +159,29 @@ export function getNewOptimisticProperties(
   properties: OptimisticPropertyValue[]
 ): OptimisticPropertyValue[] {
   return properties.filter((property) => !isPersistedPropertyId(property.id))
+}
+
+/**
+ * Builds the complete ordered list of references for an entity's `properties`
+ * field from the optimistic property set. Persisted properties are referenced
+ * by identity without rewriting them (their scalar changes were already applied
+ * via `applyOptimisticPropertyScalars`); genuinely new properties are written
+ * into the store and referenced.
+ *
+ * Returning the full list — instead of appending to the existing one — lets an
+ * optimistic edit that *drops* a property (e.g. clearing a select value) take
+ * effect immediately, matching the canonical server state that the
+ * post-mutation refetch will write.
+ */
+export function buildOptimisticPropertyRefs(
+  properties: OptimisticPropertyValue[],
+  toReference: ToReference
+): unknown[] {
+  return properties.flatMap((property) => {
+    const isNew = !isPersistedPropertyId(property.id)
+    const ref = toReference(property, isNew)
+    return ref ? [ref] : []
+  })
 }
 
 export function applyOptimisticPropertyScalars(

--- a/web/api/mutations/tasks/updateTask.plan.ts
+++ b/web/api/mutations/tasks/updateTask.plan.ts
@@ -8,7 +8,7 @@ import {
 import { getParsedDocument } from '@/data/hooks/queryHelpers'
 import { registerOptimisticPlan } from '@/data/mutations/registry'
 import type { OptimisticPlan, OptimisticPatch } from '@/data/mutations/types'
-import { buildOptimisticProperties, readEntityProperties, applyOptimisticPropertyScalars, getNewOptimisticProperties } from '@/api/mutations/shared/optimisticProperties'
+import { buildOptimisticProperties, readEntityProperties, applyOptimisticPropertyScalars, buildOptimisticPropertyRefs } from '@/api/mutations/shared/optimisticProperties'
 
 type UpdateTaskVariables = {
   id: string,
@@ -107,19 +107,14 @@ export const updateTaskOptimisticPlan: OptimisticPlan<UpdateTaskVariables> = {
             const existingProps = readEntityProperties(cache, 'TaskType', taskId)
             const optimisticProperties = buildOptimisticProperties(existingProps, data.properties, taskId)
             applyOptimisticPropertyScalars(cache, optimisticProperties)
-            const newProperties = getNewOptimisticProperties(optimisticProperties)
-            if (newProperties.length > 0) {
-              fields['properties'] = (existing, details) => {
-                const { toReference } = details as unknown as {
-                  toReference: (obj: unknown, mergeIntoStore?: boolean) => unknown,
-                }
-                const current = Array.isArray(existing) ? existing : []
-                const newRefs = newProperties.flatMap((property) => {
-                  const ref = toReference(property, true)
-                  return ref ? [ref] : []
-                })
-                return [...current, ...newRefs]
+            // Replace the whole `properties` list with the optimistic set so an
+            // edit that removes a property (e.g. clearing a select) is reflected
+            // immediately instead of lingering until the server refetch.
+            fields['properties'] = (_existing, details) => {
+              const { toReference } = details as unknown as {
+                toReference: (obj: unknown, mergeIntoStore?: boolean) => unknown,
               }
+              return buildOptimisticPropertyRefs(optimisticProperties, toReference)
             }
           }
           cache.modify({

--- a/web/components/common/VirtualizedCardGrid.tsx
+++ b/web/components/common/VirtualizedCardGrid.tsx
@@ -3,12 +3,14 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import clsx from 'clsx'
 import { useVirtualizer } from '@tanstack/react-virtual'
-import { chunkIntoRows, columnsForWidth } from '@/utils/virtualGrid'
+import { chunkIntoRows, columnsForWidth, overscanRowsForBuffer } from '@/utils/virtualGrid'
 import { isNearBottom } from '@/utils/nearBottom'
 
 const DEFAULT_GAP_PX = 12
 const DEFAULT_ESTIMATE_ROW_HEIGHT_PX = 220
-const DEFAULT_OVERSCAN_ROWS = 4
+// Render roughly a screenful of extra rows in each direction so a fast mobile
+// momentum scroll cannot outrun the render and reveal a blank list.
+const DEFAULT_OVERSCAN_ROWS = overscanRowsForBuffer(800, DEFAULT_ESTIMATE_ROW_HEIGHT_PX)
 const DEFAULT_VIRTUALIZE_THRESHOLD = 40
 const REACH_BOTTOM_THRESHOLD_PX = 600
 

--- a/web/components/layout/Page.tsx
+++ b/web/components/layout/Page.tsx
@@ -618,7 +618,7 @@ export const Page = ({
           onMenuClick={() => setIsSidebarOpen(!isSidebarOpen)}
           isMenuOpen={isSidebarOpen}
         />
-        <main className="flex-col-2 grow pr-4 px-4">
+        <main className="flex-col-2 grow min-h-0 pr-4 px-4">
           {children}
           <div className="min-h-16" />
         </main>

--- a/web/components/properties/EditablePropertyCell.tsx
+++ b/web/components/properties/EditablePropertyCell.tsx
@@ -29,10 +29,12 @@ function stopRowActivation(e: React.SyntheticEvent) {
 
 import { formatLocalCalendarDate, parseApiDateTime, parseLocalCalendarDate, serializeDateTimeForApi } from '@/utils/calendarDate'
 
-function wrapTrigger(node: ReactNode): ReactNode {
+function wrapTrigger(node: ReactNode, definitionId: string): ReactNode {
   return (
     <div
       className="flex min-w-32 w-full max-w-full"
+      data-testid="editable-property-cell"
+      data-property-definition-id={definitionId}
       onPointerDown={stopRowActivation}
       onClick={stopRowActivation}
       onMouseDown={stopRowActivation}
@@ -100,7 +102,8 @@ export function EditablePropertyCell({
         }}
       >
         <EditablePropertyTriggerDisplay property={property as PropertyValueType | undefined} fieldType={fieldType} />
-      </InTableTextEditPopUp>
+      </InTableTextEditPopUp>,
+      definitionId
     )
   }
   case FieldType.FieldTypeNumber: {
@@ -114,7 +117,8 @@ export function EditablePropertyCell({
         }}
       >
         <EditablePropertyTriggerDisplay property={property as PropertyValueType | undefined} fieldType={fieldType} />
-      </InTableNumberEditPopUp>
+      </InTableNumberEditPopUp>,
+      definitionId
     )
   }
   case FieldType.FieldTypeCheckbox: {
@@ -128,7 +132,8 @@ export function EditablePropertyCell({
         }}
       >
         <EditablePropertyTriggerDisplay property={property as PropertyValueType | undefined} fieldType={fieldType} />
-      </InTableCheckboxEditPopUp>
+      </InTableCheckboxEditPopUp>,
+      definitionId
     )
   }
   case FieldType.FieldTypeDate: {
@@ -147,7 +152,8 @@ export function EditablePropertyCell({
         }}
       >
         <EditablePropertyTriggerDisplay property={property as PropertyValueType | undefined} fieldType={fieldType} />
-      </InTableDateTimeEditPopUp>
+      </InTableDateTimeEditPopUp>,
+      definitionId
     )
   }
   case FieldType.FieldTypeDateTime: {
@@ -164,7 +170,8 @@ export function EditablePropertyCell({
         }}
       >
         <EditablePropertyTriggerDisplay property={property as PropertyValueType | undefined} fieldType={fieldType} />
-      </InTableDateTimeEditPopUp>
+      </InTableDateTimeEditPopUp>,
+      definitionId
     )
   }
   case FieldType.FieldTypeSelect: {
@@ -180,7 +187,8 @@ export function EditablePropertyCell({
         }}
       >
         <EditablePropertyTriggerDisplay property={property as PropertyValueType | undefined} fieldType={fieldType} />
-      </InTableSingleSelectEditPopUp>
+      </InTableSingleSelectEditPopUp>,
+      definitionId
     )
   }
   case FieldType.FieldTypeMultiSelect: {
@@ -198,7 +206,8 @@ export function EditablePropertyCell({
         }}
       >
         <EditablePropertyTriggerDisplay property={property as PropertyValueType | undefined} fieldType={fieldType} />
-      </InTableMultiSelectEditPopUp>
+      </InTableMultiSelectEditPopUp>,
+      definitionId
     )
   }
   case FieldType.FieldTypeUser: {

--- a/web/components/tables/PatientList.tsx
+++ b/web/components/tables/PatientList.tsx
@@ -24,6 +24,7 @@ import { LIST_PAGE_SIZE } from '@/utils/listPaging'
 import { useAccumulatedPagination } from '@/hooks/useAccumulatedPagination'
 import { RowRefreshingGate } from '@/components/tables/RowRefreshingGate'
 import { VirtualizedCardGrid } from '@/components/common/VirtualizedCardGrid'
+import { overscanRowsForBuffer } from '@/utils/virtualGrid'
 import { ListLoadingHint } from '@/components/common/ListLoadingHint'
 import { useIsPrinting } from '@/hooks/useIsPrinting'
 import { isNearBottom } from '@/utils/nearBottom'
@@ -93,6 +94,11 @@ const LOCATION_KIND_HEADERS: Record<LocationKindColumn, string> = {
 }
 
 const ADMITTED_OR_WAITING_STATES: PatientState[] = [PatientState.Admitted, PatientState.Wait]
+
+const TABLE_ROW_ESTIMATE_PX = 56
+// Render about a screenful of extra rows so fast mobile scrolling does not
+// outrun the virtualizer and flash an empty table.
+const TABLE_OVERSCAN_ROWS = overscanRowsForBuffer(800, TABLE_ROW_ESTIMATE_PX)
 
 const PATIENT_CARD_PRIMARY_COLUMN_IDS = new Set([
   'name',
@@ -1216,7 +1222,7 @@ export const PatientList = forwardRef<PatientListRef, PatientListProps>(({
           >
             <div className={clsx(listLayout === 'table' ? clsx('block', useBoxScroll && 'flex-1 min-h-0 flex flex-col') : 'hidden print:block')}>
               <TableDisplay
-                virtualized={useBoxScroll ? { scroll: 'container', estimateRowHeight: 56 } : false}
+                virtualized={useBoxScroll ? { scroll: 'container', estimateRowHeight: TABLE_ROW_ESTIMATE_PX, overscan: TABLE_OVERSCAN_ROWS } : false}
                 tableHeaderProps={useBoxScroll ? { isSticky: true } : undefined}
                 containerProps={{
                   className: clsx(useBoxScroll && 'flex-1 min-h-0 max-h-[calc(100dvh-12rem)] overflow-y-auto', 'print:max-h-none print:overflow-visible'),

--- a/web/components/tables/TaskList.tsx
+++ b/web/components/tables/TaskList.tsx
@@ -33,6 +33,7 @@ import { LIST_PAGE_SIZE } from '@/utils/listPaging'
 import { TaskCardView } from '@/components/tasks/TaskCardView'
 import { RefreshingTaskIdsContext, TaskRowRefreshingGate } from '@/components/tables/TaskRowRefreshingGate'
 import { VirtualizedCardGrid } from '@/components/common/VirtualizedCardGrid'
+import { overscanRowsForBuffer } from '@/utils/virtualGrid'
 import { ListLoadingHint } from '@/components/common/ListLoadingHint'
 import { useIsPrinting } from '@/hooks/useIsPrinting'
 import { isNearBottom } from '@/utils/nearBottom'
@@ -50,6 +51,11 @@ import type { DialogState } from '@/types/DialogState'
 function taskListDataSyncKey(tasks: TaskViewModel[]): string {
   return tasks.map(t => `${t.id}:${t.done}:${t.updateDate.getTime()}`).join('\0')
 }
+
+const TABLE_ROW_ESTIMATE_PX = 56
+// Render about a screenful of extra rows so fast mobile scrolling does not
+// outrun the virtualizer and flash an empty table.
+const TABLE_OVERSCAN_ROWS = overscanRowsForBuffer(800, TABLE_ROW_ESTIMATE_PX)
 
 export type TaskViewModel = {
   id: string,
@@ -1069,7 +1075,7 @@ export const TaskList = forwardRef<TaskListRef, TaskListProps>(({ tasks: initial
             >
               <div className={clsx('w-full', listLayout === 'table' ? clsx('block', useBoxScroll && 'flex-1 min-h-0 flex flex-col') : 'hidden print:block')}>
                 <TableDisplay
-                  virtualized={useBoxScroll ? { scroll: 'container', estimateRowHeight: 56 } : false}
+                  virtualized={useBoxScroll ? { scroll: 'container', estimateRowHeight: TABLE_ROW_ESTIMATE_PX, overscan: TABLE_OVERSCAN_ROWS } : false}
                   tableHeaderProps={useBoxScroll ? { isSticky: true } : undefined}
                   containerProps={{
                     className: clsx(useBoxScroll && 'flex-1 min-h-0 max-h-[calc(100dvh-12rem)] overflow-y-auto', 'print:max-h-none print:overflow-visible'),

--- a/web/data/cache/policies.test.ts
+++ b/web/data/cache/policies.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+import { InMemoryCache } from '@apollo/client/cache'
+import { buildCacheConfig } from './policies'
+import { GetPatientsDocument, type GetPatientsQuery } from '@/api/gql/generated'
+
+type TestProperty = {
+  id: string,
+  definitionId: string,
+  selectValue?: string | null,
+  textValue?: string | null,
+}
+
+function makeProperty(prop: TestProperty) {
+  return {
+    __typename: 'PropertyValueType',
+    id: prop.id,
+    definition: {
+      __typename: 'PropertyDefinitionType',
+      id: prop.definitionId,
+      name: 'Property',
+      description: null,
+      fieldType: 'FIELD_TYPE_SELECT',
+      isActive: true,
+      allowedEntities: ['PATIENT'],
+      options: ['a', 'b'],
+    },
+    textValue: prop.textValue ?? null,
+    numberValue: null,
+    booleanValue: null,
+    dateValue: null,
+    dateTimeValue: null,
+    selectValue: prop.selectValue ?? null,
+    multiSelectValues: null,
+    userValue: null,
+    user: null,
+    team: null,
+  }
+}
+
+function writePatientWithProperties(cache: InMemoryCache, properties: TestProperty[]) {
+  cache.writeQuery<GetPatientsQuery>({
+    query: GetPatientsDocument,
+    variables: { pagination: { pageIndex: 0, pageSize: 25 } },
+    data: ({
+      patients: [
+        {
+          __typename: 'PatientType',
+          id: 'patient-1',
+          name: 'Jane Doe',
+          firstname: 'Jane',
+          lastname: 'Doe',
+          birthdate: '1990-01-01',
+          sex: 'FEMALE',
+          state: 'ADMITTED',
+          updateDate: '2026-01-01T00:00:00Z',
+          assignedLocation: null,
+          assignedLocations: [],
+          clinic: null,
+          position: null,
+          teams: [],
+          tasks: [],
+          properties: properties.map(makeProperty),
+        },
+      ],
+      patientsTotal: 1,
+    } as unknown) as GetPatientsQuery,
+  })
+}
+
+function readPatientProperties(cache: InMemoryCache): Array<{ definition: { id: string }, selectValue: string | null }> {
+  const data = cache.readQuery<GetPatientsQuery>({
+    query: GetPatientsDocument,
+    variables: { pagination: { pageIndex: 0, pageSize: 25 } },
+  })
+  return (data?.patients?.[0]?.properties ?? []) as unknown as Array<{ definition: { id: string }, selectValue: string | null }>
+}
+
+describe('patient properties cache policy', () => {
+  it('reflects a canonical server response that removes a property (clearing a selection)', () => {
+    const cache = new InMemoryCache(buildCacheConfig())
+    writePatientWithProperties(cache, [
+      { id: 'uuid-keep', definitionId: 'def-keep', selectValue: 'def-keep-opt-0' },
+      { id: 'uuid-clear', definitionId: 'def-clear', selectValue: 'def-clear-opt-1' },
+    ])
+
+    // Server reload after the user cleared the `def-clear` selection: the
+    // canonical response no longer contains that property.
+    writePatientWithProperties(cache, [
+      { id: 'uuid-keep', definitionId: 'def-keep', selectValue: 'def-keep-opt-0' },
+    ])
+
+    const props = readPatientProperties(cache)
+    expect(props.map(p => p.definition.id)).toEqual(['def-keep'])
+  })
+
+  it('reflects a canonical server response that changes a selection value', () => {
+    const cache = new InMemoryCache(buildCacheConfig())
+    writePatientWithProperties(cache, [
+      { id: 'uuid-1', definitionId: 'def-1', selectValue: 'def-1-opt-0' },
+    ])
+
+    writePatientWithProperties(cache, [
+      { id: 'uuid-1', definitionId: 'def-1', selectValue: 'def-1-opt-1' },
+    ])
+
+    const props = readPatientProperties(cache)
+    expect(props).toHaveLength(1)
+    expect(props[0]!.selectValue).toBe('def-1-opt-1')
+  })
+})

--- a/web/data/cache/policies.ts
+++ b/web/data/cache/policies.ts
@@ -5,33 +5,14 @@ const propertyValueKeyFields = (object: Readonly<Record<string, unknown>>): read
   return id != null && id !== '' ? ['id'] : false
 }
 
-type ReadFieldFromReference = (fieldName: string, from: Reference) => unknown
-
-const getReferenceIdentity = (readField: ReadFieldFromReference, reference: Reference): string => {
-  const id = readField('id', reference)
-  return typeof id === 'string' && id !== '' ? id : JSON.stringify(reference)
-}
-
-const mergeReferencesByIdentity = (
-  existing: readonly Reference[] = [],
-  incoming: readonly Reference[] = [],
-  { readField }: { readField: ReadFieldFromReference }
-): readonly Reference[] => {
-  const incomingIdentities = new Set<string>()
-  for (const reference of incoming) {
-    incomingIdentities.add(getReferenceIdentity(readField, reference))
-  }
-
-  const mergedReferences = [...incoming]
-  for (const reference of existing) {
-    const identity = getReferenceIdentity(readField, reference)
-    if (!incomingIdentities.has(identity)) {
-      mergedReferences.push(reference)
-    }
-  }
-
-  return mergedReferences
-}
+// An entity's `properties` array is always returned in full by every query that
+// selects it (GetPatients, GetPatient, GetTasks, GetTask, GetOverviewData), so
+// the canonical server response is authoritative. Replacing (rather than
+// unioning) the array lets an edit that removes a property — e.g. clearing a
+// select value — actually take effect; a union merge would re-add the removed
+// property from the previous cache value and the change would silently revert
+// after the post-mutation refetch.
+const replaceProperties = (_existing: readonly Reference[] | undefined, incoming: readonly Reference[]): readonly Reference[] => incoming
 
 export function buildCacheConfig(): InMemoryCacheConfig {
   return {
@@ -60,17 +41,28 @@ export function buildCacheConfig(): InMemoryCacheConfig {
           taskPreset: { keyArgs: ['id'] },
         },
       },
-      Task: { keyFields: ['id'] },
+      Task: {
+        keyFields: ['id'],
+        fields: {
+          properties: { merge: replaceProperties },
+        },
+      },
+      TaskType: {
+        keyFields: ['id'],
+        fields: {
+          properties: { merge: replaceProperties },
+        },
+      },
       Patient: {
         keyFields: ['id'],
         fields: {
-          properties: { merge: mergeReferencesByIdentity },
+          properties: { merge: replaceProperties },
         },
       },
       PatientType: {
         keyFields: ['id'],
         fields: {
-          properties: { merge: mergeReferencesByIdentity },
+          properties: { merge: replaceProperties },
         },
       },
       User: { keyFields: ['id'] },

--- a/web/hooks/useAccumulatedPagination.test.ts
+++ b/web/hooks/useAccumulatedPagination.test.ts
@@ -5,6 +5,7 @@ import {
   materializePages,
   mergePagesById,
   mergePagesContiguousById,
+  preferNonEmptyAccumulation,
   resolveAccumulatedList
 } from './useAccumulatedPagination'
 
@@ -241,6 +242,32 @@ describe('materializePages', () => {
     const merged = materializePages([[]], lastPages, 28)
     expect(merged.map(x => x.id)).toHaveLength(25)
     expect(lastPages.has(0)).toBe(true)
+  })
+})
+
+describe('preferNonEmptyAccumulation', () => {
+  it('keeps the previous rows when a refetch momentarily reads empty but the server still has data', () => {
+    const prev = [{ id: 'a' }, { id: 'b' }]
+    expect(preferNonEmptyAccumulation(prev, [], 390)).toBe(prev)
+  })
+
+  it('allows emptying when the dataset is genuinely empty (totalCount 0)', () => {
+    const prev = [{ id: 'a' }]
+    expect(preferNonEmptyAccumulation(prev, [], 0)).toEqual([])
+  })
+
+  it('allows emptying when the total is unknown', () => {
+    const prev = [{ id: 'a' }]
+    expect(preferNonEmptyAccumulation(prev, [], undefined)).toEqual([])
+  })
+
+  it('passes through a non-empty next result unchanged', () => {
+    const next = [{ id: 'a' }, { id: 'c' }]
+    expect(preferNonEmptyAccumulation([{ id: 'a' }], next, 390)).toBe(next)
+  })
+
+  it('does not keep previous when there was nothing to preserve', () => {
+    expect(preferNonEmptyAccumulation([], [], 390)).toEqual([])
   })
 })
 

--- a/web/hooks/useAccumulatedPagination.ts
+++ b/web/hooks/useAccumulatedPagination.ts
@@ -95,6 +95,25 @@ export function getContiguousLoadedThrough<T>(
 }
 
 /**
+ * Guards against blanking an already-populated list. When a fresh materialize
+ * reads as empty (e.g. a transient incomplete cache read during a
+ * scroll-triggered refetch) but we already have rows and the server still
+ * reports a non-empty dataset, keep the previous rows instead of flashing an
+ * empty list. Genuine emptying flows through the reset effect (filter/search
+ * change) or arrives with `totalCount === 0`.
+ */
+export function preferNonEmptyAccumulation<T>(
+  prev: T[],
+  next: T[],
+  totalCount: number | undefined
+): T[] {
+  if (next.length === 0 && prev.length > 0 && (totalCount ?? 0) > 0) {
+    return prev
+  }
+  return next
+}
+
+/**
  * Merges the per-page reads into a single accumulated list while remembering the
  * last non-empty result for each page in `lastPages`. A page that reads as
  * `undefined` (momentarily unreadable, e.g. while a refetch is in flight) falls
@@ -200,7 +219,10 @@ export function useAccumulatedPagination<T extends { id: string }>(options: {
       const next = materializePages(rawReads, lastPagesRef.current, totalCountRef.current)
       const through = getContiguousLoadedThrough(pageIndex, resolvePageRead)
       setContiguousLoadedThrough(through)
-      setAccumulated(prev => (samePaginatedListItems(prev, next) ? prev : next))
+      setAccumulated(prev => {
+        const resolved = preferNonEmptyAccumulation(prev, next, totalCountRef.current)
+        return samePaginatedListItems(prev, resolved) ? prev : resolved
+      })
     }
     materialize()
     const unsubscribes: Array<() => void> = []

--- a/web/utils/virtualGrid.test.ts
+++ b/web/utils/virtualGrid.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { chunkIntoRows, columnsForWidth } from './virtualGrid'
+import { chunkIntoRows, columnsForWidth, overscanRowsForBuffer } from './virtualGrid'
 
 describe('columnsForWidth', () => {
   it('returns at least one column for any positive width', () => {
@@ -35,5 +35,23 @@ describe('chunkIntoRows', () => {
 
   it('treats non-positive column counts as a single column', () => {
     expect(chunkIntoRows([1, 2, 3], 0)).toEqual([[1], [2], [3]])
+  })
+})
+
+describe('overscanRowsForBuffer', () => {
+  it('renders enough rows to cover the pixel buffer ahead of the viewport', () => {
+    expect(overscanRowsForBuffer(600, 56)).toBe(11)
+    expect(overscanRowsForBuffer(600, 220)).toBe(6)
+  })
+
+  it('never drops below the minimum overscan', () => {
+    expect(overscanRowsForBuffer(50, 56)).toBe(6)
+    expect(overscanRowsForBuffer(600, 56, 20)).toBe(20)
+  })
+
+  it('falls back to the minimum for invalid inputs', () => {
+    expect(overscanRowsForBuffer(0, 56)).toBe(6)
+    expect(overscanRowsForBuffer(600, 0)).toBe(6)
+    expect(overscanRowsForBuffer(Number.NaN, 56)).toBe(6)
   })
 })

--- a/web/utils/virtualGrid.ts
+++ b/web/utils/virtualGrid.ts
@@ -9,6 +9,23 @@ export function columnsForWidth(
   return Math.max(1, columns)
 }
 
+/**
+ * Number of rows to render outside the visible window so that a fast (e.g. mobile
+ * momentum) scroll does not outrun React's render and reveal blank space. Derives
+ * the row count from a target pixel buffer and the (estimated) row height, never
+ * dropping below `minRows`.
+ */
+export function overscanRowsForBuffer(
+  bufferPx: number,
+  rowHeightPx: number,
+  minRows = 6
+): number {
+  const floor = Math.max(1, Math.floor(minRows))
+  if (!Number.isFinite(bufferPx) || bufferPx <= 0) return floor
+  if (!Number.isFinite(rowHeightPx) || rowHeightPx <= 0) return floor
+  return Math.max(floor, Math.ceil(bufferPx / rowHeightPx))
+}
+
 export function chunkIntoRows<T>(items: readonly T[], columns: number): T[][] {
   const safeColumns = Math.max(1, Math.floor(columns) || 1)
   const rows: T[][] = []


### PR DESCRIPTION
Follow-up fixes for the list virtualization rollout (#293). Addresses the four issues reported:

### 1. Fast scrolling flashed an empty list on mobile
The page had **two nested scroll containers** — the outer page (`Page` → `main`) and the virtualized list. The shared `<main>` was missing `min-h-0`, which broke the flex height-constraint chain, so the list fell back to its `max-h` cap and overflowed the page. On mobile, touch/momentum scrolling then moved the **outer** page while the container-scroll virtualizer (which only listens to the inner container) never updated, revealing the empty spacer region.

**Fix:** add `min-h-0` to `<main>` so the virtualized list becomes the sole scroller and fills the remaining height. Also raise the table/card virtualizer `overscan` (new `overscanRowsForBuffer` helper) so a fast momentum scroll can't outrun the render.

### 2. Inline edits propagated to the backend but reverted after refetch
`PatientType.properties` used a **union merge** cache policy that re-added stale/removed property references from the previous cache value, and freshly-added optimistic properties were *incomplete* reads (missing `user`/`team`), which made the active `cache-and-network` queries revalidate and overwrite the optimistic value.

**Fix:** every query that selects `properties` returns the full set, so the server response is authoritative — replace the union merge with replace semantics, and make optimistic properties complete reads.

### 3. Could not clear a select property (empty selection)
Same union merge re-added the cleared property after the refetch, and the optimistic plan only ever *appended* properties (never removed them).

**Fix:** replace semantics + rebuilding the **full** optimistic `properties` list now drop a cleared property immediately and keep it gone after the refetch.

### 4. Removed the redundant outer scrollbar
Fixing the flex height chain (see #1) makes the list explicitly fill the rest of the page, so only the inner list scrolls. `max-h-[calc(100dvh-12rem)]` is kept as the bound for the consumer pages that render the list outside the flex chain (`/view/[uid]`, `/location/[id]`).

### Tests
- `data/cache/policies.test.ts` — clearing/editing a property reflects the canonical server response.
- `updatePatient.plan.list.integration.test.ts` — optimistic clear removes a list property and keeps the read complete.
- `virtualGrid.test.ts` — `overscanRowsForBuffer` coverage.

Validated locally: `npm run lint`, `npm run check-translations`, `npm run test` (146 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PVQuCiDGvDxwZCWBY8gUj

---
_Generated by [Claude Code](https://claude.ai/code/session_017PVQuCiDGvDxwZCWBY8gUj)_