### PR TITLE
feat(tables): sticky header on page scroll, natural column widths, full print output

### DIFF
--- a/tests/e2e/patient-table.spec.ts
+++ b/tests/e2e/patient-table.spec.ts
@@ -219,4 +219,95 @@ test.describe('patient table (patient list)', () => {
     // reveal the full-height table.
     expect(metrics.appPageOverflow).toBeGreaterThan(200)
   })
+
+  test('keeps the table header visible while the page scrolls', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 })
+    await seedAuth(page)
+    await seedStoredSelection(page, ['root-1'])
+    await mockBackend(page, {
+      patients: PATIENTS,
+      propertyDefinitions: [ALLERGY_DEF],
+      rootLocations: ROOT_LOCATIONS,
+    })
+
+    await page.goto(`${BASE}/patients`)
+    await expect(page.locator(ROW_SELECTOR).first()).toBeVisible({ timeout: 20000 })
+
+    for (let step = 0; step < 3; step++) {
+      await scrollListStep(page)
+      await page.waitForTimeout(250)
+    }
+
+    const headerCell = page.locator('th[data-name="table-header-cell"]').first()
+    await expect(headerCell).toBeVisible()
+    const headerCellBox = await headerCell.boundingBox()
+    const appHeaderBox = await page.locator('[data-name="app-page-header"]').boundingBox()
+    expect(headerCellBox).not.toBeNull()
+    expect(appHeaderBox).not.toBeNull()
+    expect(headerCellBox!.y).toBeGreaterThanOrEqual(appHeaderBox!.y + appHeaderBox!.height - 1)
+    expect(headerCellBox!.y).toBeLessThan(appHeaderBox!.y + appHeaderBox!.height + 64)
+  })
+
+  test('prints every loaded row, not just the virtualized window', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 })
+    await seedAuth(page)
+    await seedStoredSelection(page, ['root-1'])
+    await mockBackend(page, {
+      patients: PATIENTS,
+      propertyDefinitions: [ALLERGY_DEF],
+      rootLocations: ROOT_LOCATIONS,
+    })
+
+    await page.goto(`${BASE}/patients`)
+    await expect(page.locator(ROW_SELECTOR).first()).toBeVisible({ timeout: 20000 })
+
+    const deadline = Date.now() + 30000
+    while (Date.now() < deadline) {
+      await scrollListStep(page)
+      await page.waitForTimeout(250)
+      const atBottom = await page.evaluate(() => {
+        const el = document.querySelector('[data-name="app-page-content"]')
+        if (!el) return false
+        return el.scrollHeight - el.scrollTop - el.clientHeight < 4
+      })
+      if (atBottom) break
+    }
+
+    expect(await page.locator(ROW_SELECTOR).count()).toBeLessThan(PATIENT_COUNT)
+
+    await page.evaluate(() => window.dispatchEvent(new Event('beforeprint')))
+    await expect.poll(() => page.locator(ROW_SELECTOR).count(), { timeout: 15000 })
+      .toBe(PATIENT_COUNT)
+
+    await page.emulateMedia({ media: 'print' })
+    const names = await visibleRowNames(page)
+    expect(new Set(names).size).toBe(PATIENT_COUNT)
+    const rows = page.locator(ROW_SELECTOR)
+    const firstBox = await rows.first().boundingBox()
+    const lastBox = await rows.last().boundingBox()
+    expect(firstBox).not.toBeNull()
+    expect(lastBox).not.toBeNull()
+    expect(lastBox!.y).toBeGreaterThan(firstBox!.y + 500)
+
+    await page.emulateMedia({ media: 'screen' })
+    await page.evaluate(() => window.dispatchEvent(new Event('afterprint')))
+  })
+
+  test('columns size to their content instead of a fixed negotiated width', async ({ page }) => {
+    await seedAuth(page)
+    await seedStoredSelection(page, ['root-1'])
+    await mockBackend(page, {
+      patients: PATIENTS,
+      propertyDefinitions: [ALLERGY_DEF],
+      rootLocations: ROOT_LOCATIONS,
+    })
+
+    await page.goto(`${BASE}/patients`)
+    await expect(page.locator(ROW_SELECTOR).first()).toBeVisible({ timeout: 20000 })
+
+    const table = page.locator('table[data-name="table"]')
+    await expect(table).toHaveAttribute('data-column-sizing', 'natural')
+    expect(await table.evaluate((el) => (el as HTMLElement).style.width)).toBe('')
+    expect(await table.evaluate((el) => getComputedStyle(el).tableLayout)).toBe('auto')
+  })
 })

--- a/web/components/properties/EditablePropertyCell.tsx
+++ b/web/components/properties/EditablePropertyCell.tsx
@@ -19,9 +19,23 @@ export type EditablePropertyCellProps = {
   onValueChanged: (input: PropertyValueInput | null) => void,
 }
 
-const editableTriggerButtonProps = {
-  className: 'justify-between group gap-x-2 w-full min-w-32 max-w-full h-auto max-h-none px-2 py-1 font-normal text-left',
-} as const
+function triggerMinWidthClass(fieldType: FieldType): string {
+  switch (fieldType) {
+  case FieldType.FieldTypeNumber:
+  case FieldType.FieldTypeCheckbox:
+    return 'min-w-16'
+  case FieldType.FieldTypeSelect:
+    return 'min-w-24'
+  default:
+    return 'min-w-32'
+  }
+}
+
+function editableTriggerButtonProps(minWidthClass: string) {
+  return {
+    className: clsx('justify-between group gap-x-2 w-full max-w-full h-auto max-h-none px-2 py-1 font-normal text-left', minWidthClass),
+  }
+}
 
 function stopRowActivation(e: React.SyntheticEvent) {
   e.stopPropagation()
@@ -29,10 +43,10 @@ function stopRowActivation(e: React.SyntheticEvent) {
 
 import { formatLocalCalendarDate, parseApiDateTime, parseLocalCalendarDate, serializeDateTimeForApi } from '@/utils/calendarDate'
 
-function wrapTrigger(node: ReactNode, definitionId: string): ReactNode {
+function wrapTrigger(node: ReactNode, definitionId: string, minWidthClass: string): ReactNode {
   return (
     <div
-      className="flex min-w-32 w-full max-w-full"
+      className={clsx('flex w-full max-w-full', minWidthClass)}
       data-testid="editable-property-cell"
       data-property-definition-id={definitionId}
       onPointerDown={stopRowActivation}
@@ -80,6 +94,8 @@ export function EditablePropertyCell({
 }: EditablePropertyCellProps) {
   const fieldType = definition.fieldType
   const definitionId = definition.id
+  const minWidthClass = triggerMinWidthClass(fieldType)
+  const buttonProps = editableTriggerButtonProps(minWidthClass)
 
   if (!allowUpdates || disabled) {
     return <PropertyCell property={property as PropertyValueType | undefined} fieldType={fieldType} />
@@ -95,7 +111,7 @@ export function EditablePropertyCell({
     return wrapTrigger(
       <InTableTextEditPopUp
         value={textVal}
-        buttonProps={editableTriggerButtonProps}
+        buttonProps={buttonProps}
         onUpdate={(next) => {
           const t = next?.trim() ?? ''
           onValueChanged(t === '' ? null : { definitionId, textValue: t })
@@ -103,7 +119,8 @@ export function EditablePropertyCell({
       >
         <EditablePropertyTriggerDisplay property={property as PropertyValueType | undefined} fieldType={fieldType} />
       </InTableTextEditPopUp>,
-      definitionId
+      definitionId,
+      minWidthClass
     )
   }
   case FieldType.FieldTypeNumber: {
@@ -111,14 +128,15 @@ export function EditablePropertyCell({
     return wrapTrigger(
       <InTableNumberEditPopUp
         value={numVal}
-        buttonProps={editableTriggerButtonProps}
+        buttonProps={buttonProps}
         onUpdate={(next) => {
           onValueChanged(next == null ? null : { definitionId, numberValue: next })
         }}
       >
         <EditablePropertyTriggerDisplay property={property as PropertyValueType | undefined} fieldType={fieldType} />
       </InTableNumberEditPopUp>,
-      definitionId
+      definitionId,
+      minWidthClass
     )
   }
   case FieldType.FieldTypeCheckbox: {
@@ -126,14 +144,15 @@ export function EditablePropertyCell({
     return wrapTrigger(
       <InTableCheckboxEditPopUp
         value={boolVal}
-        buttonProps={editableTriggerButtonProps}
+        buttonProps={buttonProps}
         onUpdate={(next) => {
           onValueChanged(next == null ? null : { definitionId, booleanValue: next })
         }}
       >
         <EditablePropertyTriggerDisplay property={property as PropertyValueType | undefined} fieldType={fieldType} />
       </InTableCheckboxEditPopUp>,
-      definitionId
+      definitionId,
+      minWidthClass
     )
   }
   case FieldType.FieldTypeDate: {
@@ -142,7 +161,7 @@ export function EditablePropertyCell({
       <InTableDateTimeEditPopUp
         mode="date"
         value={d}
-        buttonProps={editableTriggerButtonProps}
+        buttonProps={buttonProps}
         onUpdate={(next) => {
           onValueChanged(
             next == null
@@ -153,7 +172,8 @@ export function EditablePropertyCell({
       >
         <EditablePropertyTriggerDisplay property={property as PropertyValueType | undefined} fieldType={fieldType} />
       </InTableDateTimeEditPopUp>,
-      definitionId
+      definitionId,
+      minWidthClass
     )
   }
   case FieldType.FieldTypeDateTime: {
@@ -162,7 +182,7 @@ export function EditablePropertyCell({
       <InTableDateTimeEditPopUp
         mode="dateTime"
         value={d}
-        buttonProps={editableTriggerButtonProps}
+        buttonProps={buttonProps}
         onUpdate={(next) => {
           onValueChanged(
             next == null ? null : { definitionId, dateTimeValue: serializeDateTimeForApi(next) }
@@ -171,7 +191,8 @@ export function EditablePropertyCell({
       >
         <EditablePropertyTriggerDisplay property={property as PropertyValueType | undefined} fieldType={fieldType} />
       </InTableDateTimeEditPopUp>,
-      definitionId
+      definitionId,
+      minWidthClass
     )
   }
   case FieldType.FieldTypeSelect: {
@@ -181,14 +202,15 @@ export function EditablePropertyCell({
         definitionId={definitionId}
         optionLabels={definition.options}
         value={sel}
-        buttonProps={{ ...editableTriggerButtonProps, className: clsx(editableTriggerButtonProps.className, { 'pl-1': !!sel }) }}
+        buttonProps={{ ...buttonProps, className: clsx(buttonProps.className, { 'pl-1': !!sel }) }}
         onUpdate={(next) => {
           onValueChanged(next == null ? null : { definitionId, selectValue: next })
         }}
       >
         <EditablePropertyTriggerDisplay property={property as PropertyValueType | undefined} fieldType={fieldType} />
       </InTableSingleSelectEditPopUp>,
-      definitionId
+      definitionId,
+      minWidthClass
     )
   }
   case FieldType.FieldTypeMultiSelect: {
@@ -198,7 +220,7 @@ export function EditablePropertyCell({
         definitionId={definitionId}
         optionLabels={definition.options}
         value={multi}
-        buttonProps={{ ...editableTriggerButtonProps, className: clsx(editableTriggerButtonProps.className, { 'pl-1': multi.length > 0 }) }}
+        buttonProps={{ ...buttonProps, className: clsx(buttonProps.className, { 'pl-1': multi.length > 0 }) }}
         onUpdate={(next) => {
           onValueChanged(
             next == null || next.length === 0 ? null : { definitionId, multiSelectValues: next }
@@ -207,7 +229,8 @@ export function EditablePropertyCell({
       >
         <EditablePropertyTriggerDisplay property={property as PropertyValueType | undefined} fieldType={fieldType} />
       </InTableMultiSelectEditPopUp>,
-      definitionId
+      definitionId,
+      minWidthClass
     )
   }
   case FieldType.FieldTypeUser: {

--- a/web/components/tables/PatientList.tsx
+++ b/web/components/tables/PatientList.tsx
@@ -739,9 +739,9 @@ export const PatientList = forwardRef<PatientListRef, PatientListProps>(({
           </>
         ))
       },
-      minSize: 160,
-      size: 160,
-      maxSize: 200,
+      minSize: 96,
+      size: 110,
+      maxSize: 160,
     },
     {
       id: 'clinic',
@@ -852,9 +852,9 @@ export const PatientList = forwardRef<PatientListRef, PatientListProps>(({
           </Tooltip>
         ))
       },
-      minSize: 150,
-      size: 150,
-      maxSize: 200,
+      minSize: 100,
+      size: 110,
+      maxSize: 160,
     },
     {
       id: 'updateDate',
@@ -1099,6 +1099,7 @@ export const PatientList = forwardRef<PatientListRef, PatientListProps>(({
     <TableProvider
       data={patients}
       columns={columns}
+      columnSizingMode="natural"
       fillerRowCell={fillerRowCell}
       onRowClick={onRowClick}
 
@@ -1235,10 +1236,11 @@ export const PatientList = forwardRef<PatientListRef, PatientListProps>(({
                   overscan: TABLE_OVERSCAN_ROWS,
                   onReachBottom: listLayout === 'table' ? handleReachBottom : undefined,
                 } : false}
+                tableHeaderProps={usePageScroll ? { isSticky: true } : undefined}
                 containerProps={{
                   className: 'print:max-h-none print:overflow-visible',
                 }}
-                className="print-content hw-autosize-table overflow-x-auto hw-touch-scroll"
+                className="print-content overflow-x-auto hw-touch-scroll"
               />
             </div>
             {listLayout === 'card' && (

--- a/web/components/tables/TaskList.tsx
+++ b/web/components/tables/TaskList.tsx
@@ -934,6 +934,7 @@ export const TaskList = forwardRef<TaskListRef, TaskListProps>(({ tasks: initial
       <TableProvider
         data={displayedTasks}
         columns={columns}
+        columnSizingMode="natural"
         fillerRowCell={useCallback(() => (<FillerCell className="min-h-12" />), [])}
         initialState={{
           pagination: {
@@ -1072,10 +1073,11 @@ export const TaskList = forwardRef<TaskListRef, TaskListProps>(({ tasks: initial
               <div className={clsx('w-full', listLayout === 'table' ? 'block' : 'hidden print:block')}>
                 <TableDisplay
                   virtualized={usePageScroll ? { scroll: 'page', estimateRowHeight: TABLE_ROW_ESTIMATE_PX, overscan: TABLE_OVERSCAN_ROWS, onReachBottom: listLayout === 'table' ? handleReachBottom : undefined } : false}
+                  tableHeaderProps={usePageScroll ? { isSticky: true } : undefined}
                   containerProps={{
                     className: 'print:max-h-none print:overflow-visible',
                   }}
-                  className="print-content hw-autosize-table w-full overflow-x-auto hw-touch-scroll"
+                  className="print-content w-full overflow-x-auto hw-touch-scroll"
                 />
               </div>
               {listLayout === 'card' && (

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,7 +12,7 @@
         "@dnd-kit/core": "6.3.1",
         "@dnd-kit/modifiers": "9.0.0",
         "@dnd-kit/sortable": "10.0.0",
-        "@helpwave/hightide": "0.13.1",
+        "@helpwave/hightide": "0.13.2",
         "@helpwave/internationalization": "0.4.0",
         "@tailwindcss/postcss": "4.3.1",
         "@tanstack/react-query": "5.101.0",
@@ -1879,9 +1879,9 @@
       }
     },
     "node_modules/@helpwave/hightide": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@helpwave/hightide/-/hightide-0.13.1.tgz",
-      "integrity": "sha512-b2zPIhtFkp8PHrOLWOYWTlErHSx6fx7v9r8EIUmUcDOVwhaAW/PUAJGQj6DidjzCfujeE2sXU8Yp0ENBV+RtaA==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@helpwave/hightide/-/hightide-0.13.2.tgz",
+      "integrity": "sha512-WkWVWbZxWN5xU5frw8mbmArZ+5kNX3eeHy9NHkHJgKfre7Tc+iTKR3/9h89Qg/sDHDUceqN6yt/kj8wkDxwxOg==",
       "license": "MPL-2.0",
       "dependencies": {
         "@helpwave/internationalization": "0.4.0",

--- a/web/package.json
+++ b/web/package.json
@@ -28,7 +28,7 @@
     "@dnd-kit/core": "6.3.1",
     "@dnd-kit/modifiers": "9.0.0",
     "@dnd-kit/sortable": "10.0.0",
-    "@helpwave/hightide": "0.13.1",
+    "@helpwave/hightide": "0.13.2",
     "@helpwave/internationalization": "0.4.0",
     "@tailwindcss/postcss": "4.3.1",
     "@tanstack/react-query": "5.101.0",

--- a/web/style/index.css
+++ b/web/style/index.css
@@ -1,3 +1,2 @@
 @import "./colors.css";
 @import "./table-printing.css";
-@import "./table-autosize.css";

--- a/web/style/table-autosize.css
+++ b/web/style/table-autosize.css
@@ -1,4 +1,0 @@
-table[data-name="table"].hw-autosize-table {
-  table-layout: auto;
-  width: 100% !important;
-}

--- a/web/style/table-printing.css
+++ b/web/style/table-printing.css
@@ -33,7 +33,7 @@
     visibility: hidden;
   }
 
-  table[data-name="table"].hw-autosize-table [data-name="table-body-cell"] {
+  table[data-name="table"] [data-name="table-body-cell"] {
     vertical-align: top;
   }
 
@@ -42,13 +42,30 @@
     visibility: visible;
   }
 
+  [data-name="app-page"],
+  [data-name="app-page-content"],
+  [data-name="app-page-main-content"] {
+    display: block !important;
+    height: auto !important;
+    max-height: none !important;
+    overflow: visible !important;
+  }
+
+  [data-name="app-page-header"],
+  [data-name="app-sidebar-container"],
+  [data-name="app-sidebar-backdrop"] {
+    display: none !important;
+  }
+
+  [data-name="table-container"] {
+    overflow: visible !important;
+    border: none !important;
+  }
+
   .print-content {
-    position: absolute;
-    z-index: 10000 !important;
+    position: static !important;
     width: 100% !important;
     max-width: 100% !important;
-    left: 0 !important;
-    top: 0 !important;
     margin: 0 !important;
     padding: 0 !important;
     height: auto !important;
@@ -97,10 +114,12 @@
     overflow-wrap: anywhere !important;
   }
 
+  .print-content thead {
+    display: table-header-group;
+  }
+
   .print-content thead tr th {
-    position: sticky;
-    top: 0;
-    z-index: 1;
+    position: static !important;
     width: auto !important;
     max-width: 100% !important;
 

--- a/web/utils/propertyColumn.tsx
+++ b/web/utils/propertyColumn.tsx
@@ -55,6 +55,20 @@ function getPropertyAccessorValue(
   )
 }
 
+function getPropertySizeInformation(fieldType: FieldType) {
+  switch (fieldType) {
+  case FieldType.FieldTypeMultiSelect:
+    return { minSize: 360, size: 360, maxSize: 360 }
+  case FieldType.FieldTypeNumber:
+  case FieldType.FieldTypeCheckbox:
+    return { minSize: 90, size: 110, maxSize: 200 }
+  case FieldType.FieldTypeSelect:
+    return { minSize: 120, size: 160, maxSize: 300 }
+  default:
+    return { minSize: 220, size: 220, maxSize: 300 }
+  }
+}
+
 function getFilterData(prop: PropertyDefinitionType) {
   const filterFn = getPropertyFilterFn(prop.fieldType)
   if (filterFn === 'multiTags' || filterFn === 'singleTag') {
@@ -79,15 +93,7 @@ export function createPropertyColumn<T extends RowWithProperties>(
   const allowUpdates = !!options?.allowUpdates && !!options?.onValueChanged
   const onValueChanged = options?.onValueChanged
 
-  const sizeInformation = prop.fieldType === FieldType.FieldTypeMultiSelect ? {
-    minSize: 360,
-    size: 360,
-    maxSize: 360
-  } : {
-    minSize: 220,
-    size: 220,
-    maxSize: 300
-  }
+  const sizeInformation = getPropertySizeInformation(prop.fieldType)
 
   return {
     id: columnId,


### PR DESCRIPTION
## What & why

Follow-up to #309 (full-height page scroll). Requires **@helpwave/hightide 0.13.2** (helpwave/hightide#276) — CI stays red on `npm ci` until that PR is merged and published, then the lockfile gets synced here.

- **Sticky table header** — the column header stays visible directly below the AppPage header while the page scrolls (hightide `isSticky` with the page virtualization mode).
- **Natural column widths** — the patient/task tables use hightide's new `columnSizingMode: 'natural'`: no more fill-the-container negotiation, property columns shrink to their content (a one-char select no longer eats 220px) and widen as wider values load. Per-field-type minimum widths on the editable property cells (from `claude/table-column-width-29zcqb`, integrated here) keep the tap targets and padding correct. The `table-autosize` CSS `!important` override is superseded and removed.
- **Print shows every loaded row** — the print root was `position: absolute`, and Chromium clips out-of-flow content to the first page, which is why only the first rows ever printed. Printing now keeps the table in normal flow (the AppPage shell is unlocked from its `h-dvh overflow-hidden` layout in print, header/sidebar hidden), so all already-loaded rows paginate across pages and the `thead` repeats natively on each printed page.
- **Performance** — together with hightide 0.13.2, tables/grids no longer run three virtualizers in parallel (only the active scroll mode attaches observers), the width-negotiation loop is gone from the list tables, and small card grids skip virtualization entirely.

## Verification

Ran the full e2e suite locally against a production build with a local hightide 0.13.2: **28/28 pass**, including three new regression tests in `patient-table.spec.ts`:
- header stays pinned below the AppPage header after scrolling
- print renders all 77 fixture rows in flow (screen stays virtualized)
- the table uses auto layout with no inline width

Typecheck 0 errors, lint clean, 151 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01375kAPxAFypUHbqWZmWkNF