### PR TITLE
fix: opaque sticky table header and full-width list loading overlay

### DIFF
--- a/web/components/common/ListLoadingHint.tsx
+++ b/web/components/common/ListLoadingHint.tsx
@@ -33,7 +33,7 @@ export function ListLoadingHint({ active, className }: ListLoadingHintProps) {
       role="status"
       aria-live="polite"
       className={clsx(
-        'absolute inset-x-3 bottom-3 z-10 rounded-lg p-2 flex items-center justify-center gap-2 py-3 text-sm text-description pointer-events-none print:hidden',
+        'absolute inset-x-0 bottom-0 z-10 rounded-b-lg p-2 flex items-center justify-center gap-2 py-3 text-sm text-description pointer-events-none print:hidden',
         'bg-linear-to-t from-background via-background/90 to-transparent',
         className
       )}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,7 +12,7 @@
         "@dnd-kit/core": "6.3.1",
         "@dnd-kit/modifiers": "9.0.0",
         "@dnd-kit/sortable": "10.0.0",
-        "@helpwave/hightide": "0.13.2",
+        "@helpwave/hightide": "0.13.4",
         "@helpwave/internationalization": "0.4.0",
         "@tailwindcss/postcss": "4.3.1",
         "@tanstack/react-query": "5.101.0",
@@ -1879,9 +1879,8 @@
       }
     },
     "node_modules/@helpwave/hightide": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@helpwave/hightide/-/hightide-0.13.2.tgz",
-      "integrity": "sha512-WkWVWbZxWN5xU5frw8mbmArZ+5kNX3eeHy9NHkHJgKfre7Tc+iTKR3/9h89Qg/sDHDUceqN6yt/kj8wkDxwxOg==",
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@helpwave/hightide/-/hightide-0.13.4.tgz",
       "license": "MPL-2.0",
       "dependencies": {
         "@helpwave/internationalization": "0.4.0",

--- a/web/package.json
+++ b/web/package.json
@@ -28,7 +28,7 @@
     "@dnd-kit/core": "6.3.1",
     "@dnd-kit/modifiers": "9.0.0",
     "@dnd-kit/sortable": "10.0.0",
-    "@helpwave/hightide": "0.13.2",
+    "@helpwave/hightide": "0.13.4",
     "@helpwave/internationalization": "0.4.0",
     "@tailwindcss/postcss": "4.3.1",
     "@tanstack/react-query": "5.101.0",


### PR DESCRIPTION
- update to @helpwave/hightide 0.13.4, which paints the page-sticky
  table header above positioned cell content so rows no longer shine
  through it while scrolling
- the list loading hint now stretches to the edges of the list area
  instead of leaving 12px safe areas, so its gradient covers the bottom
  corners of the table; it stays an absolutely positioned overlay, so
  neither the loading state nor scrollbars resize the table container

The package-lock integrity hash for hightide 0.13.4 needs a refresh via
npm install once the package is published.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012mpEpBWtQJiTDEw3U3BGez