### PR TITLE
Add quick due date preset buttons to task creation

### DIFF
--- a/web/components/tasks/DueDateQuickSelect.tsx
+++ b/web/components/tasks/DueDateQuickSelect.tsx
@@ -1,0 +1,69 @@
+import { Button } from '@helpwave/hightide'
+import { useTasksTranslation } from '@/i18n/useTasksTranslation'
+import { DueDateUtils } from '@/utils/dueDate'
+
+const HOUR_OFFSETS = [1, 3, 6, 12, 24]
+const DAY_OFFSETS = [2, 4]
+
+interface DueDateQuickSelectProps {
+  onSelect: (dueDate: Date) => void,
+}
+
+export const DueDateQuickSelect = ({ onSelect }: DueDateQuickSelectProps) => {
+  const translation = useTasksTranslation()
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex flex-wrap gap-1.5">
+        <Button
+          size="xs"
+          color="neutral"
+          coloringStyle="outline"
+          onClick={() => onSelect(DueDateUtils.dateTimeInHours(0))}
+        >
+          {translation('dueDateNow')}
+        </Button>
+        {HOUR_OFFSETS.map((hours) => (
+          <Button
+            key={hours}
+            size="xs"
+            color="neutral"
+            coloringStyle="outline"
+            onClick={() => onSelect(DueDateUtils.dateTimeInHours(hours))}
+          >
+            {translation('dueDateInHours', { hours })}
+          </Button>
+        ))}
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        <Button
+          size="xs"
+          color="neutral"
+          coloringStyle="outline"
+          onClick={() => onSelect(DueDateUtils.dateOnlyInDays(0))}
+        >
+          {translation('dueDateToday')}
+        </Button>
+        <Button
+          size="xs"
+          color="neutral"
+          coloringStyle="outline"
+          onClick={() => onSelect(DueDateUtils.dateOnlyInDays(1))}
+        >
+          {translation('dueDateTomorrow')}
+        </Button>
+        {DAY_OFFSETS.map((days) => (
+          <Button
+            key={days}
+            size="xs"
+            color="neutral"
+            coloringStyle="outline"
+            onClick={() => onSelect(DueDateUtils.dateOnlyInDays(days))}
+          >
+            {translation('dueDateInDays', { days })}
+          </Button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/web/components/tasks/TaskDataEditor.tsx
+++ b/web/components/tasks/TaskDataEditor.tsx
@@ -30,6 +30,7 @@ import { DateDisplay } from '@/components/Date/DateDisplay'
 import { AssigneeSelect } from './AssigneeSelect'
 import { UserInfoPopup } from '@/components/UserInfoPopup'
 import { DueDateUtils, getTaskDueDateFlexibleInputProps } from '@/utils/dueDate'
+import { DueDateQuickSelect } from './DueDateQuickSelect'
 import { PatientDetailView } from '@/components/patients/PatientDetailView'
 import { ErrorDialog } from '@/components/ErrorDialog'
 import { useCreateDraftDirty } from '@/hooks/useCreateDraftDirty'
@@ -85,6 +86,7 @@ export const TaskDataEditor = ({
   const [errorDialog, setErrorDialog] = useState<DialogState<{ message?: string }>>({ isOpen: false, data: { message: undefined } })
   const [isShowingPatientDialog, setIsShowingPatientDialog] = useState<boolean>(false)
   const [assigneeUserPopupId, setAssigneeUserPopupId] = useState<string | null>(null)
+  const [dueDateQuickSelectCount, setDueDateQuickSelectCount] = useState(0)
 
   const isEditMode = id !== null
   const taskId = id
@@ -493,15 +495,25 @@ export const TaskDataEditor = ({
                   updateValue(next)
                 }
                 return (
-                  <FlexibleDateTimeInput
-                    key={isEditMode ? `${taskId}-${dueDate?.getTime() ?? 'pending'}` : 'create'}
-                    {...getTaskDueDateFlexibleInputProps()}
-                    {...focusableElementProps}
-                    {...interactionStates}
-                    value={value ?? null}
-                    onValueChange={commitDueDate}
-                    onEditComplete={commitDueDate}
-                  />
+                  <div className="flex flex-col gap-2">
+                    <FlexibleDateTimeInput
+                      key={isEditMode ? `${taskId}-${dueDate?.getTime() ?? 'pending'}` : `create-${dueDateQuickSelectCount}`}
+                      {...getTaskDueDateFlexibleInputProps()}
+                      {...focusableElementProps}
+                      {...interactionStates}
+                      value={value ?? null}
+                      onValueChange={commitDueDate}
+                      onEditComplete={commitDueDate}
+                    />
+                    {!isEditMode && (
+                      <DueDateQuickSelect
+                        onSelect={(nextDueDate) => {
+                          commitDueDate(nextDueDate)
+                          setDueDateQuickSelectCount((count) => count + 1)
+                        }}
+                      />
+                    )}
+                  </div>
                 )
               }}
             </FormField>

--- a/web/i18n/translations.ts
+++ b/web/i18n/translations.ts
@@ -87,6 +87,11 @@ export type TasksTranslationEntries = {
   'diverse': string,
   'done': string,
   'dueDate': string,
+  'dueDateInDays': (values: { days: number }) => string,
+  'dueDateInHours': (values: { hours: number }) => string,
+  'dueDateNow': string,
+  'dueDateToday': string,
+  'dueDateTomorrow': string,
   'duplicate': string,
   'edit': string,
   'editPatient': string,
@@ -426,6 +431,27 @@ export const tasksTranslation: Translation<TasksTranslationLocales, Partial<Task
     'diverse': `Divers`,
     'done': `Fertig`,
     'dueDate': `Fälligkeitsdatum`,
+    'dueDateInDays': ({ days }): string => {
+      let _out: string = ''
+      _out += `+`
+      _out += TranslationGen.resolvePlural(days, {
+        '=1': `${days} Tag`,
+        'other': `${days} Tage`,
+      })
+      return _out
+    },
+    'dueDateInHours': ({ hours }): string => {
+      let _out: string = ''
+      _out += `+`
+      _out += TranslationGen.resolvePlural(hours, {
+        '=1': `${hours} Stunde`,
+        'other': `${hours} Stunden`,
+      })
+      return _out
+    },
+    'dueDateNow': `Jetzt`,
+    'dueDateToday': `Heute`,
+    'dueDateTomorrow': `Morgen`,
     'duplicate': `Duplizieren`,
     'edit': `Bearbeiten`,
     'editPatient': `Patient bearbeiten`,
@@ -872,6 +898,27 @@ export const tasksTranslation: Translation<TasksTranslationLocales, Partial<Task
     'diverse': `Diverse`,
     'done': `Done`,
     'dueDate': `Due Date`,
+    'dueDateInDays': ({ days }): string => {
+      let _out: string = ''
+      _out += `+`
+      _out += TranslationGen.resolvePlural(days, {
+        '=1': `${days} day`,
+        'other': `${days} days`,
+      })
+      return _out
+    },
+    'dueDateInHours': ({ hours }): string => {
+      let _out: string = ''
+      _out += `+`
+      _out += TranslationGen.resolvePlural(hours, {
+        '=1': `${hours} hour`,
+        'other': `${hours} hours`,
+      })
+      return _out
+    },
+    'dueDateNow': `Now`,
+    'dueDateToday': `Today`,
+    'dueDateTomorrow': `Tomorrow`,
     'duplicate': `Duplicate`,
     'edit': `Edit`,
     'editPatient': `Edit Patient`,
@@ -1319,6 +1366,27 @@ export const tasksTranslation: Translation<TasksTranslationLocales, Partial<Task
     'diverse': `Diverso`,
     'done': `Hecho`,
     'dueDate': `Fecha de vencimiento`,
+    'dueDateInDays': ({ days }): string => {
+      let _out: string = ''
+      _out += `+`
+      _out += TranslationGen.resolvePlural(days, {
+        '=1': `${days} día`,
+        'other': `${days} días`,
+      })
+      return _out
+    },
+    'dueDateInHours': ({ hours }): string => {
+      let _out: string = ''
+      _out += `+`
+      _out += TranslationGen.resolvePlural(hours, {
+        '=1': `${hours} hora`,
+        'other': `${hours} horas`,
+      })
+      return _out
+    },
+    'dueDateNow': `Ahora`,
+    'dueDateToday': `Hoy`,
+    'dueDateTomorrow': `Mañana`,
     'duplicate': `Duplicate`,
     'edit': `Editar`,
     'editPatient': `Editar paciente`,
@@ -1765,6 +1833,27 @@ export const tasksTranslation: Translation<TasksTranslationLocales, Partial<Task
     'diverse': `Divers`,
     'done': `Terminé`,
     'dueDate': `Date d'échéance`,
+    'dueDateInDays': ({ days }): string => {
+      let _out: string = ''
+      _out += `+`
+      _out += TranslationGen.resolvePlural(days, {
+        '=1': `${days} jour`,
+        'other': `${days} jours`,
+      })
+      return _out
+    },
+    'dueDateInHours': ({ hours }): string => {
+      let _out: string = ''
+      _out += `+`
+      _out += TranslationGen.resolvePlural(hours, {
+        '=1': `${hours} heure`,
+        'other': `${hours} heures`,
+      })
+      return _out
+    },
+    'dueDateNow': `Maintenant`,
+    'dueDateToday': `Aujourd'hui`,
+    'dueDateTomorrow': `Demain`,
     'duplicate': `Duplicate`,
     'edit': `Modifier`,
     'editPatient': `Modifier le patient`,
@@ -2211,6 +2300,27 @@ export const tasksTranslation: Translation<TasksTranslationLocales, Partial<Task
     'diverse': `Divers`,
     'done': `Klaar`,
     'dueDate': `Vervaldatum`,
+    'dueDateInDays': ({ days }): string => {
+      let _out: string = ''
+      _out += `+`
+      _out += TranslationGen.resolvePlural(days, {
+        '=1': `${days} dag`,
+        'other': `${days} dagen`,
+      })
+      return _out
+    },
+    'dueDateInHours': ({ hours }): string => {
+      let _out: string = ''
+      _out += `+`
+      _out += TranslationGen.resolvePlural(hours, {
+        '=1': `${hours} uur`,
+        'other': `${hours} uur`,
+      })
+      return _out
+    },
+    'dueDateNow': `Nu`,
+    'dueDateToday': `Vandaag`,
+    'dueDateTomorrow': `Morgen`,
     'duplicate': `Duplicate`,
     'edit': `Bewerken`,
     'editPatient': `Patiënt bewerken`,
@@ -2660,6 +2770,27 @@ export const tasksTranslation: Translation<TasksTranslationLocales, Partial<Task
     'diverse': `Diverso`,
     'done': `Concluído`,
     'dueDate': `Data de vencimento`,
+    'dueDateInDays': ({ days }): string => {
+      let _out: string = ''
+      _out += `+`
+      _out += TranslationGen.resolvePlural(days, {
+        '=1': `${days} dia`,
+        'other': `${days} dias`,
+      })
+      return _out
+    },
+    'dueDateInHours': ({ hours }): string => {
+      let _out: string = ''
+      _out += `+`
+      _out += TranslationGen.resolvePlural(hours, {
+        '=1': `${hours} hora`,
+        'other': `${hours} horas`,
+      })
+      return _out
+    },
+    'dueDateNow': `Agora`,
+    'dueDateToday': `Hoje`,
+    'dueDateTomorrow': `Amanhã`,
     'duplicate': `Duplicate`,
     'edit': `Editar`,
     'editPatient': `Editar paciente`,

--- a/web/locales/de-DE.arb
+++ b/web/locales/de-DE.arb
@@ -100,6 +100,25 @@
   "diverse": "Divers",
   "done": "Fertig",
   "dueDate": "Fälligkeitsdatum",
+  "dueDateInDays": "+{days, plural, =1{# Tag} other{# Tage}}",
+  "@dueDateInDays": {
+    "placeholders": {
+      "days": {
+        "type": "number"
+      }
+    }
+  },
+  "dueDateInHours": "+{hours, plural, =1{# Stunde} other{# Stunden}}",
+  "@dueDateInHours": {
+    "placeholders": {
+      "hours": {
+        "type": "number"
+      }
+    }
+  },
+  "dueDateNow": "Jetzt",
+  "dueDateToday": "Heute",
+  "dueDateTomorrow": "Morgen",
   "edit": "Bearbeiten",
   "editPatient": "Patient bearbeiten",
   "editTask": "Aufgabe bearbeiten",

--- a/web/locales/en-US.arb
+++ b/web/locales/en-US.arb
@@ -100,6 +100,25 @@
   "duplicate": "Duplicate",
   "done": "Done",
   "dueDate": "Due Date",
+  "dueDateInDays": "+{days, plural, =1{# day} other{# days}}",
+  "@dueDateInDays": {
+    "placeholders": {
+      "days": {
+        "type": "number"
+      }
+    }
+  },
+  "dueDateInHours": "+{hours, plural, =1{# hour} other{# hours}}",
+  "@dueDateInHours": {
+    "placeholders": {
+      "hours": {
+        "type": "number"
+      }
+    }
+  },
+  "dueDateNow": "Now",
+  "dueDateToday": "Today",
+  "dueDateTomorrow": "Tomorrow",
   "edit": "Edit",
   "editPatient": "Edit Patient",
   "editTask": "Edit Task",

--- a/web/locales/es-ES.arb
+++ b/web/locales/es-ES.arb
@@ -60,6 +60,25 @@
   "duplicate": "Duplicate",
   "done": "Hecho",
   "dueDate": "Fecha de vencimiento",
+  "dueDateInDays": "+{days, plural, =1{# día} other{# días}}",
+  "@dueDateInDays": {
+    "placeholders": {
+      "days": {
+        "type": "number"
+      }
+    }
+  },
+  "dueDateInHours": "+{hours, plural, =1{# hora} other{# horas}}",
+  "@dueDateInHours": {
+    "placeholders": {
+      "hours": {
+        "type": "number"
+      }
+    }
+  },
+  "dueDateNow": "Ahora",
+  "dueDateToday": "Hoy",
+  "dueDateTomorrow": "Mañana",
   "edit": "Editar",
   "editPatient": "Editar paciente",
   "editTask": "Editar tarea",

--- a/web/locales/fr-FR.arb
+++ b/web/locales/fr-FR.arb
@@ -60,6 +60,25 @@
   "duplicate": "Duplicate",
   "done": "Terminé",
   "dueDate": "Date d''échéance",
+  "dueDateInDays": "+{days, plural, =1{# jour} other{# jours}}",
+  "@dueDateInDays": {
+    "placeholders": {
+      "days": {
+        "type": "number"
+      }
+    }
+  },
+  "dueDateInHours": "+{hours, plural, =1{# heure} other{# heures}}",
+  "@dueDateInHours": {
+    "placeholders": {
+      "hours": {
+        "type": "number"
+      }
+    }
+  },
+  "dueDateNow": "Maintenant",
+  "dueDateToday": "Aujourd''hui",
+  "dueDateTomorrow": "Demain",
   "edit": "Modifier",
   "editPatient": "Modifier le patient",
   "editTask": "Modifier la tâche",

--- a/web/locales/nl-NL.arb
+++ b/web/locales/nl-NL.arb
@@ -60,6 +60,25 @@
   "duplicate": "Duplicate",
   "done": "Klaar",
   "dueDate": "Vervaldatum",
+  "dueDateInDays": "+{days, plural, =1{# dag} other{# dagen}}",
+  "@dueDateInDays": {
+    "placeholders": {
+      "days": {
+        "type": "number"
+      }
+    }
+  },
+  "dueDateInHours": "+{hours, plural, =1{# uur} other{# uur}}",
+  "@dueDateInHours": {
+    "placeholders": {
+      "hours": {
+        "type": "number"
+      }
+    }
+  },
+  "dueDateNow": "Nu",
+  "dueDateToday": "Vandaag",
+  "dueDateTomorrow": "Morgen",
   "edit": "Bewerken",
   "editPatient": "Patiënt bewerken",
   "editTask": "Taak bewerken",

--- a/web/locales/pt-BR.arb
+++ b/web/locales/pt-BR.arb
@@ -60,6 +60,25 @@
   "duplicate": "Duplicate",
   "done": "Concluído",
   "dueDate": "Data de vencimento",
+  "dueDateInDays": "+{days, plural, =1{# dia} other{# dias}}",
+  "@dueDateInDays": {
+    "placeholders": {
+      "days": {
+        "type": "number"
+      }
+    }
+  },
+  "dueDateInHours": "+{hours, plural, =1{# hora} other{# horas}}",
+  "@dueDateInHours": {
+    "placeholders": {
+      "hours": {
+        "type": "number"
+      }
+    }
+  },
+  "dueDateNow": "Agora",
+  "dueDateToday": "Hoje",
+  "dueDateTomorrow": "Amanhã",
   "edit": "Editar",
   "editPatient": "Editar paciente",
   "editTask": "Editar tarefa",

--- a/web/utils/dueDate.test.ts
+++ b/web/utils/dueDate.test.ts
@@ -80,3 +80,73 @@ describe('DueDateUtils.serializeForApi', () => {
     expect(DueDateUtils.serializeForApi(undefined)).toBeNull()
   })
 })
+
+const wallClock = (date: Date) => ({
+  year: date.getFullYear(),
+  month: date.getMonth(),
+  day: date.getDate(),
+  hours: date.getHours(),
+  minutes: date.getMinutes(),
+  seconds: date.getSeconds(),
+  milliseconds: date.getMilliseconds(),
+})
+
+describe('DueDateUtils.dateTimeInHours', () => {
+  it('returns the current wall clock in the app timezone with zeroed seconds for an offset of 0', () => {
+    const now = new Date('2026-07-05T14:32:41.512Z')
+    const result = DueDateUtils.dateTimeInHours(0, now, 'Europe/Berlin')
+    expect(wallClock(result)).toEqual({ year: 2026, month: 6, day: 5, hours: 16, minutes: 32, seconds: 0, milliseconds: 0 })
+  })
+
+  it('adds the given number of hours', () => {
+    const now = new Date('2026-07-05T14:32:41.512Z')
+    const result = DueDateUtils.dateTimeInHours(3, now, 'Europe/Berlin')
+    expect(wallClock(result)).toEqual({ year: 2026, month: 6, day: 5, hours: 19, minutes: 32, seconds: 0, milliseconds: 0 })
+  })
+
+  it('rolls over to the next day for offsets crossing midnight', () => {
+    const now = new Date('2026-07-05T20:00:00.000Z')
+    const result = DueDateUtils.dateTimeInHours(6, now, 'Europe/Berlin')
+    expect(wallClock(result)).toEqual({ year: 2026, month: 6, day: 6, hours: 4, minutes: 0, seconds: 0, milliseconds: 0 })
+  })
+
+  it('never produces a date-only value', () => {
+    const now = new Date('2026-07-05T21:59:59.999Z')
+    for (const hours of [0, 1, 3, 6, 12, 24]) {
+      expect(DueDateUtils.isDateOnly(DueDateUtils.dateTimeInHours(hours, now, 'Europe/Berlin'))).toBe(false)
+    }
+  })
+})
+
+describe('DueDateUtils.dateOnlyInDays', () => {
+  it('returns the end-of-day sentinel for today with an offset of 0', () => {
+    const now = new Date('2026-07-05T14:32:41.512Z')
+    const result = DueDateUtils.dateOnlyInDays(0, now, 'Europe/Berlin')
+    expect(wallClock(result)).toEqual({ year: 2026, month: 6, day: 5, hours: 23, minutes: 59, seconds: 59, milliseconds: 999 })
+  })
+
+  it('uses the calendar day of the app timezone, not UTC', () => {
+    const now = new Date('2026-07-05T22:30:00.000Z')
+    const result = DueDateUtils.dateOnlyInDays(0, now, 'Europe/Berlin')
+    expect(wallClock(result)).toEqual({ year: 2026, month: 6, day: 6, hours: 23, minutes: 59, seconds: 59, milliseconds: 999 })
+  })
+
+  it('adds the given number of days', () => {
+    const now = new Date('2026-07-05T14:32:41.512Z')
+    expect(wallClock(DueDateUtils.dateOnlyInDays(1, now, 'Europe/Berlin')).day).toBe(6)
+    expect(wallClock(DueDateUtils.dateOnlyInDays(4, now, 'Europe/Berlin')).day).toBe(9)
+  })
+
+  it('rolls over month boundaries', () => {
+    const now = new Date('2026-07-30T08:00:00.000Z')
+    const result = DueDateUtils.dateOnlyInDays(2, now, 'Europe/Berlin')
+    expect(wallClock(result)).toEqual({ year: 2026, month: 7, day: 1, hours: 23, minutes: 59, seconds: 59, milliseconds: 999 })
+  })
+
+  it('always produces a date-only value', () => {
+    const now = new Date('2026-07-05T14:32:41.512Z')
+    for (const days of [0, 1, 2, 4]) {
+      expect(DueDateUtils.isDateOnly(DueDateUtils.dateOnlyInDays(days, now, 'Europe/Berlin'))).toBe(true)
+    }
+  })
+})

--- a/web/utils/dueDate.ts
+++ b/web/utils/dueDate.ts
@@ -1,4 +1,4 @@
-import { parseApiDateTime, serializeDateTimeForApi } from '@/utils/calendarDate'
+import { getAppTimezone, parseApiDateTime, serializeDateTimeForApi } from '@/utils/calendarDate'
 import { DateUtils } from '@helpwave/hightide'
 
 const DATE_ONLY_HOURS = 23
@@ -98,6 +98,19 @@ export const DueDateUtils = {
       instant: DueDateUtils.toDisplayInstant(zoned, timeZone),
       isDateOnly,
     }
+  },
+
+  dateTimeInHours: (hours: number, now: Date = new Date(), timeZone: string = getAppTimezone()): Date => {
+    const date = DateUtils.toZonedDate(new Date(now.getTime() + hours * 60 * 60 * 1000), timeZone)
+    date.setSeconds(0, 0)
+    return date
+  },
+
+  dateOnlyInDays: (days: number, now: Date = new Date(), timeZone: string = getAppTimezone()): Date => {
+    const date = DateUtils.toZonedDate(now, timeZone)
+    date.setDate(date.getDate() + days)
+    date.setHours(DATE_ONLY_HOURS, DATE_ONLY_MINUTES, DATE_ONLY_SECONDS, DATE_ONLY_MILLISECONDS)
+    return date
   },
 
   serializeForApi: (dueDate: Date | null | undefined, timeZone?: string): string | null => {


### PR DESCRIPTION
## What

Adds two rows of small preset buttons below the due date input in the task creation drawer:

- **Datetime presets**: `Now`, `+1 hour`, `+3 hours`, `+6 hours`, `+12 hours`, `+24 hours` — set a full datetime due date (seconds zeroed, current time plus offset).
- **Date-only presets**: `Today`, `Tomorrow`, `+2 days`, `+4 days` — set a date-only due date using the existing end-of-day sentinel (23:59:59.999), so the input switches to date mode without a time.

The due date stays **empty by default**; a value is only set when a preset is clicked or entered manually. The buttons appear only in create mode, not when editing an existing task.

## How

- New `DueDateQuickSelect` component (`web/components/tasks/DueDateQuickSelect.tsx`) using hightide `Button size="xs"` with `flex-wrap` rows so they wrap cleanly on mobile.
- New `DueDateUtils.dateTimeInHours` / `DueDateUtils.dateOnlyInDays` helpers that compute the preset in the configured app timezone (`RUNTIME_TIMEZONE`), matching the existing `parseFromApi`/`serializeForApi` wall-clock convention.
- `TaskDataEditor` remounts the `FlexibleDateTimeInput` (keyed by a click counter) when a preset is applied, since the input derives its date/dateTime mode only on mount — same pattern the edit mode already uses.
- New translation keys (`dueDateNow`, `dueDateToday`, `dueDateTomorrow`, `dueDateInHours`, `dueDateInDays`) added to all six locales with ICU plurals; `translations.ts` regenerated via `npm run build-intl`.

## Validation

- `npm run lint` (tsc + eslint): passes (one pre-existing unrelated warning in `PatientList.tsx`).
- `npm test`: 150 tests pass, including new unit tests for the preset helpers (timezone handling, day/month rollover, sentinel invariants).
- `npm run check-translations`: all keys exist in every locale.
- Verified in a Chromium browser at 375px (mobile) and 1280px (desktop): due date starts empty, datetime presets fill date + time, date presets fill date-only, buttons wrap with no horizontal overflow. Mobile screenshots:

| Datetime preset (+3 hours) | Date-only preset (Tomorrow) |
| --- | --- |
| input shows `07/05/2026 - 15:27` in dateTime mode | input shows `07/06/2026` in date mode |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011FUW7ckxf9AFki2eubR3sX

---
_Generated by [Claude Code](https://claude.ai/code/session_011FUW7ckxf9AFki2eubR3sX)_