### PR TITLE
Add proxied full-stack e2e (docker images + nginx) and fix DISTINCT sort crash

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
         with:
@@ -66,3 +69,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.component }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.component }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -285,9 +285,108 @@ jobs:
             /tmp/frontend.log
           retention-days: 7
 
+  e2e-proxy:
+    name: E2E (docker stack via nginx proxy)
+    needs: [backend-lint, frontend]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build backend image
+        uses: docker/build-push-action@v7
+        with:
+          context: backend
+          push: false
+          load: true
+          tags: local/tasks-backend:e2e
+          cache-from: type=gha,scope=backend
+          cache-to: type=gha,mode=max,scope=backend
+
+      - name: Build web image
+        uses: docker/build-push-action@v7
+        with:
+          context: web
+          push: false
+          load: true
+          tags: local/tasks-web:e2e
+          cache-from: type=gha,scope=web
+          cache-to: type=gha,mode=max,scope=web
+
+      - name: Build proxy image
+        uses: docker/build-push-action@v7
+        with:
+          context: proxy
+          push: false
+          load: true
+          tags: local/tasks-proxy:e2e
+          cache-from: type=gha,scope=proxy
+          cache-to: type=gha,mode=max,scope=proxy
+
+      - name: Start the stack
+        env:
+          BACKEND_IMAGE: local/tasks-backend:e2e
+          WEB_IMAGE: local/tasks-web:e2e
+          PROXY_IMAGE: local/tasks-proxy:e2e
+        run: docker compose -f docker-compose.e2e.yml up -d
+
+      - name: Wait for the stack behind the proxy
+        run: |
+          echo "Waiting for keycloak (realm import)..."
+          timeout 180 bash -c 'until curl -fs http://localhost/keycloak/realms/tasks/.well-known/openid-configuration > /dev/null; do sleep 3; done'
+          echo "Waiting for the backend (graphql must answer, 5xx means not routed/up yet)..."
+          timeout 180 bash -c 'until [ "$(curl -s -o /dev/null -w "%{http_code}" -X POST -H "content-type: application/json" -d "{\"query\":\"{ __typename }\"}" http://localhost/graphql)" -lt 500 ]; do sleep 3; done'
+          echo "Waiting for the frontend..."
+          timeout 180 bash -c 'until curl -fs http://localhost/ > /dev/null; do sleep 3; done'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: tests/package-lock.json
+
+      - name: Install E2E test dependencies
+        working-directory: tests
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: tests
+        run: npx playwright install --with-deps chromium
+
+      - name: Run proxied E2E tests
+        working-directory: tests
+        env:
+          CI: true
+          E2E_PROXY_TARGET: "1"
+          E2E_BASE_URL: http://localhost
+        run: npx playwright test e2e/proxy-fullstack.spec.ts
+
+      - name: Dump stack logs
+        if: failure()
+        run: docker compose -f docker-compose.e2e.yml logs --no-color > /tmp/stack.log 2>&1 || true
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report-proxy
+          path: tests/playwright-report/
+          retention-days: 30
+
+      - name: Upload stack logs
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: proxy-stack-logs
+          path: /tmp/stack.log
+          retention-days: 7
+
   ci:
     name: CI
-    needs: [backend-tests, simulator-lint, frontend, e2e-tests]
+    needs: [backend-tests, simulator-lint, frontend, e2e-tests, e2e-proxy]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -296,7 +395,8 @@ jobs:
           if [[ "${{ needs.backend-tests.result }}" != "success" ]] \
             || [[ "${{ needs.simulator-lint.result }}" != "success" ]] \
             || [[ "${{ needs.frontend.result }}" != "success" ]] \
-            || [[ "${{ needs.e2e-tests.result }}" != "success" ]]; then
+            || [[ "${{ needs.e2e-tests.result }}" != "success" ]] \
+            || [[ "${{ needs.e2e-proxy.result }}" != "success" ]]; then
             echo "One or more required jobs failed or were skipped."
             exit 1
           fi

--- a/E2E_TESTING.md
+++ b/E2E_TESTING.md
@@ -1,5 +1,50 @@
 # E2E Testing Guide
 
+There are two e2e setups:
+
+1. **Mock-based tests** (most specs under `tests/e2e/`): run the real Next.js
+   frontend and stub the GraphQL/OIDC network boundary. Fast, deterministic,
+   no backend required.
+2. **Proxied full-stack tests** (`tests/e2e/proxy-fullstack.spec.ts`): run the
+   production-like docker-compose stack — nginx proxy in front of web, backend
+   and Keycloak — built from the current commit's Docker images. These catch
+   routing issues (`/graphql`, `/keycloak/...`, `/auth/callback`) and verify
+   filtering/sorting against the real query engine.
+
+## Running the Proxied Full-Stack Tests
+
+1. **Build the images for your commit** (or use published ones):
+   ```bash
+   docker build -t local/tasks-backend:e2e backend
+   docker build -t local/tasks-web:e2e web
+   docker build -t local/tasks-proxy:e2e proxy
+   ```
+
+2. **Start the stack** (ephemeral, no persistent volumes):
+   ```bash
+   BACKEND_IMAGE=local/tasks-backend:e2e \
+   WEB_IMAGE=local/tasks-web:e2e \
+   PROXY_IMAGE=local/tasks-proxy:e2e \
+   docker compose -f docker-compose.e2e.yml up -d
+   ```
+
+3. **Wait for readiness** (Keycloak realm import takes a while):
+   ```bash
+   curl -fs http://localhost/keycloak/realms/tasks/.well-known/openid-configuration
+   curl -fs http://localhost/
+   ```
+
+4. **Run the tests against the proxy**:
+   ```bash
+   cd tests
+   E2E_PROXY_TARGET=1 E2E_BASE_URL=http://localhost npx playwright test e2e/proxy-fullstack.spec.ts
+   ```
+
+The `E2E_PROXY_TARGET=1` gate keeps these tests skipped during the mock-based
+runs. In CI the `e2e-proxy` job (`.github/workflows/tests.yml`) performs these
+steps automatically, rebuilding the commit's images from the shared Buildx
+cache of the Docker Build workflow.
+
 ## Running E2E Tests Locally
 
 ### Prerequisites

--- a/backend/api/query/engine.py
+++ b/backend/api/query/engine.py
@@ -66,8 +66,9 @@ async def apply_unified_query(
         if text:
             stmt = handler["apply_search"](stmt, search, ctx)
 
-    if ctx.get("needs_distinct"):
+    if ctx.get("needs_distinct") or bool(getattr(stmt, "_distinct", False)):
         stmt = dedupe_orm_select_by_root_id(stmt, handler["root_model"])
+        ctx.clear()
         ctx["needs_distinct"] = False
 
     if not for_count:

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,0 +1,104 @@
+services:
+  keycloak-postgres:
+    image: postgres:15.15
+    environment:
+      POSTGRES_DB: "keycloak"
+      POSTGRES_USER: "keycloak"
+      POSTGRES_PASSWORD: "password"
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.4
+    environment:
+      KC_DB: "postgres"
+      KC_DB_URL: "jdbc:postgresql://keycloak-postgres:5432/keycloak"
+      KC_DB_USERNAME: "keycloak"
+      KC_DB_PASSWORD: "password"
+
+      KC_HOSTNAME_STRICT: false
+      KC_PROXY: edge
+      KC_HTTP_RELATIVE_PATH: /keycloak
+      KC_HTTP_ENABLED: true
+
+      KEYCLOAK_ADMIN: "admin"
+      KEYCLOAK_ADMIN_PASSWORD: "admin"
+    command: start --import-realm
+    depends_on:
+      - keycloak-postgres
+    volumes:
+      - "./keycloak:/opt/keycloak/data/import:ro"
+
+  postgres:
+    image: postgres:15.15
+    environment:
+      POSTGRES_DB: "postgres"
+      POSTGRES_USER: "postgres"
+      POSTGRES_PASSWORD: "password"
+
+  redis:
+    image: redis:8.4
+    command: redis-server --requirepass password
+
+  influxdb:
+    image: influxdb:2.7
+    environment:
+      DOCKER_INFLUXDB_INIT_MODE: "setup"
+      DOCKER_INFLUXDB_INIT_USERNAME: "admin"
+      DOCKER_INFLUXDB_INIT_PASSWORD: "password"
+      DOCKER_INFLUXDB_INIT_ORG: "tasks"
+      DOCKER_INFLUXDB_INIT_BUCKET: "audit"
+      DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: "tasks-token-secret"
+
+  backend:
+    image: ${BACKEND_IMAGE:-ghcr.io/helpwave/tasks-backend:latest}
+    restart: on-failure
+    environment:
+      DATABASE_HOSTNAME: "postgres"
+      DATABASE_NAME: "postgres"
+      DATABASE_USERNAME: "postgres"
+      DATABASE_PASSWORD: "password"
+
+      REDIS_HOSTNAME: "redis"
+      REDIS_PASSWORD: "password"
+
+      ISSUER_URI: "http://keycloak:8080/keycloak/realms/tasks"
+      PUBLIC_ISSUER_URI: "http://localhost/keycloak/realms/tasks"
+      CLIENT_ID: "tasks-backend"
+      CLIENT_SECRET: "tasks-secret"
+
+      ENV: "development"
+      SCAFFOLD_DIRECTORY: "/scaffold"
+
+      INFLUXDB_URL: "http://influxdb:8086"
+      INFLUXDB_TOKEN: "tasks-token-secret"
+      INFLUXDB_ORG: "tasks"
+      INFLUXDB_BUCKET: "audit"
+    volumes:
+      - "./scaffold:/scaffold:ro"
+    depends_on:
+      - postgres
+      - redis
+      - influxdb
+
+  web:
+    image: ${WEB_IMAGE:-ghcr.io/helpwave/tasks-web:latest}
+    environment:
+      RUNTIME_GRAPHQL_ENDPOINT: "http://localhost/graphql"
+      RUNTIME_ISSUER_URI: "http://localhost/keycloak/realms/tasks"
+      RUNTIME_REDIRECT_URI: "http://localhost/auth/callback"
+      RUNTIME_POST_LOGOUT_REDIRECT_URI: "http://localhost/"
+      RUNTIME_CLIENT_ID: "tasks-web"
+    depends_on:
+      - backend
+
+  proxy:
+    image: ${PROXY_IMAGE:-ghcr.io/helpwave/tasks-proxy:latest}
+    environment:
+      KEYCLOAK_HOST: keycloak:8080
+      BACKEND_HOST: backend:80
+      FRONTEND_HOST: web:80
+    ports:
+      - "80:80"
+    depends_on:
+      - keycloak
+      - backend
+      - web

--- a/tests/e2e/proxy-fullstack.spec.ts
+++ b/tests/e2e/proxy-fullstack.spec.ts
@@ -1,0 +1,265 @@
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test'
+import {
+  ROW_SELECTOR,
+  addSorting,
+  openSortingPanel,
+  setSortDirection,
+  visibleRowFirstCells,
+} from './support/filterSortUi'
+
+const PROXY_TARGET = process.env.E2E_PROXY_TARGET === '1'
+const BASE = (process.env.E2E_BASE_URL || 'http://localhost').replace(/\/$/, '')
+
+const RUN_ID = `e2e${Date.now().toString(36)}`
+
+const USERNAME = process.env.E2E_USERNAME || 'test'
+const PASSWORD = process.env.E2E_PASSWORD || 'test'
+const CLIENT_ID = 'tasks-web'
+const TOKEN_URL = `${BASE}/keycloak/realms/tasks/protocol/openid-connect/token`
+
+async function getAccessToken(request: APIRequestContext): Promise<string> {
+  const response = await request.post(TOKEN_URL, {
+    form: {
+      grant_type: 'password',
+      client_id: CLIENT_ID,
+      username: USERNAME,
+      password: PASSWORD,
+      scope: 'openid profile email organization',
+    },
+  })
+  expect(response.ok(), `token endpoint through the proxy: ${response.status()}`).toBeTruthy()
+  const body = await response.json() as { access_token?: string }
+  expect(body.access_token, 'access token from the proxied keycloak').toBeTruthy()
+  return body.access_token!
+}
+
+async function gql<T = Record<string, unknown>>(
+  request: APIRequestContext,
+  token: string,
+  query: string,
+  variables?: Record<string, unknown>
+): Promise<T> {
+  const response = await request.post(`${BASE}/graphql`, {
+    headers: { authorization: `Bearer ${token}` },
+    data: { query, variables: variables ?? {} },
+  })
+  expect(response.ok(), `graphql through the proxy: ${response.status()}`).toBeTruthy()
+  const body = await response.json() as { data?: T, errors?: Array<{ message: string }> }
+  expect(body.errors, `graphql errors: ${JSON.stringify(body.errors)}`).toBeUndefined()
+  return body.data as T
+}
+
+type Me = { id: string, username: string, rootLocations: Array<{ id: string, title: string, kind: string }> }
+
+async function fetchMe(request: APIRequestContext, token: string): Promise<Me> {
+  const data = await gql<{ me: Me }>(request, token, `
+    query { me { id username rootLocations { id title kind } } }
+  `)
+  expect(data.me, 'me through the proxy').toBeTruthy()
+  return data.me
+}
+
+type SeededContext = {
+  token: string,
+  me: Me,
+  rootLocationIds: string[],
+  patients: Array<{ id: string, name: string, lastname: string }>,
+}
+
+async function seedData(request: APIRequestContext): Promise<SeededContext> {
+  const token = await getAccessToken(request)
+  const me = await fetchMe(request, token)
+  expect(me.rootLocations.length, 'user has root locations (scaffold import)').toBeGreaterThan(0)
+  const rootLocationIds = me.rootLocations.map(l => l.id)
+
+  const { locationNodes } = await gql<{ locationNodes: Array<{ id: string, title: string, kind: string }> }>(
+    request,
+    token,
+    `query { locationNodes { id title kind } }`
+  )
+  const clinic = locationNodes.find(l => l.kind === 'CLINIC')
+  expect(clinic, 'a clinic exists in the scaffold data').toBeTruthy()
+
+  const fixtures = [
+    { firstname: 'Zoe', lastname: `${RUN_ID}-alpha`, birthdate: '1990-01-10' },
+    { firstname: 'Max', lastname: `${RUN_ID}-mid`, birthdate: '1970-05-20' },
+    { firstname: 'Amy', lastname: `${RUN_ID}-zeta`, birthdate: '1980-09-30' },
+  ]
+  const patients: SeededContext['patients'] = []
+  for (const f of fixtures) {
+    const { createPatient } = await gql<{ createPatient: { id: string, name: string, lastname: string } }>(
+      request,
+      token,
+      `mutation Create($data: CreatePatientInput!) {
+        createPatient(data: $data) { id name lastname }
+      }`,
+      {
+        data: {
+          firstname: f.firstname,
+          lastname: f.lastname,
+          birthdate: f.birthdate,
+          sex: 'FEMALE',
+          state: 'ADMITTED',
+          clinicId: clinic!.id,
+        },
+      }
+    )
+    patients.push(createPatient)
+
+    await gql(request, token, `
+      mutation CreateTask($data: CreateTaskInput!) {
+        createTask(data: $data) { id title }
+      }`,
+    {
+      data: {
+        title: `Task ${f.lastname}`,
+        patientId: createPatient.id,
+        assigneeIds: [me.id],
+      },
+    })
+  }
+
+  return { token, me, rootLocationIds, patients }
+}
+
+test.describe('full stack behind the nginx proxy', () => {
+  test.skip(!PROXY_TARGET, 'requires the docker proxy stack (E2E_PROXY_TARGET=1)')
+  test.describe.configure({ mode: 'serial' })
+
+  let seeded: SeededContext
+
+  test('proxy routes /, /keycloak and /graphql to the right services', async ({ request }) => {
+    const home = await request.get(`${BASE}/`)
+    expect(home.status()).toBe(200)
+    expect(home.headers()['content-type'] ?? '').toContain('text/html')
+
+    const oidc = await request.get(`${BASE}/keycloak/realms/tasks/.well-known/openid-configuration`)
+    expect(oidc.status()).toBe(200)
+    const oidcBody = await oidc.json() as { issuer?: string, token_endpoint?: string }
+    expect(oidcBody.issuer ?? '').toContain('/keycloak/realms/tasks')
+
+    const graphql = await request.post(`${BASE}/graphql`, { data: { query: '{ __typename }' } })
+    expect(graphql.status()).toBeLessThan(500)
+    expect(graphql.headers()['content-type'] ?? '').not.toContain('text/html')
+  })
+
+  test('authenticates through the proxied keycloak and reads data', async ({ request }) => {
+    seeded = await seedData(request)
+    expect(seeded.me.username).toBe(USERNAME)
+    expect(seeded.patients).toHaveLength(3)
+  })
+
+  test('backend filters and sorts patients through the proxy', async ({ request }) => {
+    const { token, rootLocationIds } = seeded
+    const query = `
+      query Patients($rootLocationIds: [ID!], $filters: [QueryFilterClauseInput!], $sorts: [QuerySortClauseInput!]) {
+        patients(rootLocationIds: $rootLocationIds, filters: $filters, sorts: $sorts) { id lastname }
+        patientsTotal(rootLocationIds: $rootLocationIds, filters: $filters, sorts: $sorts)
+      }`
+    const containsRun = [{
+      fieldKey: 'name',
+      operator: 'CONTAINS',
+      value: { stringValue: RUN_ID },
+    }]
+
+    const asc = await gql<{ patients: Array<{ lastname: string }>, patientsTotal: number }>(
+      request, token, query,
+      { rootLocationIds, filters: containsRun, sorts: [{ fieldKey: 'name', direction: 'ASC' }] }
+    )
+    expect(asc.patientsTotal).toBe(3)
+    expect(asc.patients.map(p => p.lastname)).toEqual([
+      `${RUN_ID}-alpha`, `${RUN_ID}-mid`, `${RUN_ID}-zeta`,
+    ])
+
+    const desc = await gql<{ patients: Array<{ lastname: string }> }>(
+      request, token, query,
+      { rootLocationIds, filters: containsRun, sorts: [{ fieldKey: 'name', direction: 'DESC' }] }
+    )
+    expect(desc.patients.map(p => p.lastname)).toEqual([
+      `${RUN_ID}-zeta`, `${RUN_ID}-mid`, `${RUN_ID}-alpha`,
+    ])
+
+    const byBirthdate = await gql<{ patients: Array<{ lastname: string }> }>(
+      request, token, query,
+      { rootLocationIds, filters: containsRun, sorts: [{ fieldKey: 'birthdate', direction: 'ASC' }] }
+    )
+    expect(byBirthdate.patients.map(p => p.lastname)).toEqual([
+      `${RUN_ID}-mid`, `${RUN_ID}-zeta`, `${RUN_ID}-alpha`,
+    ])
+
+    const byUpdated = await gql<{ patients: Array<{ lastname: string }> }>(
+      request, token, query,
+      { rootLocationIds, filters: containsRun, sorts: [{ fieldKey: 'updateDate', direction: 'DESC' }] }
+    )
+    expect(byUpdated.patients).toHaveLength(3)
+
+    const excluded = await gql<{ patients: Array<{ lastname: string }>, patientsTotal: number }>(
+      request, token, query,
+      {
+        rootLocationIds,
+        filters: [{ fieldKey: 'name', operator: 'NOT_CONTAINS', value: { stringValue: RUN_ID } }],
+        sorts: [],
+      }
+    )
+    expect(excluded.patients.every(p => !p.lastname.includes(RUN_ID))).toBe(true)
+  })
+
+  test('backend sorts tasks by patient through the proxy (issue #213)', async ({ request }) => {
+    const { token, me, rootLocationIds } = seeded
+    const query = `
+      query Tasks($rootLocationIds: [ID!], $assigneeId: ID, $filters: [QueryFilterClauseInput!], $sorts: [QuerySortClauseInput!]) {
+        tasks(rootLocationIds: $rootLocationIds, assigneeId: $assigneeId, filters: $filters, sorts: $sorts) {
+          id title patient { lastname }
+        }
+      }`
+    const filters = [{ fieldKey: 'title', operator: 'CONTAINS', value: { stringValue: RUN_ID } }]
+
+    const asc = await gql<{ tasks: Array<{ patient: { lastname: string } | null }> }>(
+      request, token, query,
+      { rootLocationIds, assigneeId: me.id, filters, sorts: [{ fieldKey: 'patient', direction: 'ASC' }] }
+    )
+    expect(asc.tasks.map(t => t.patient?.lastname)).toEqual([
+      `${RUN_ID}-zeta`, `${RUN_ID}-mid`, `${RUN_ID}-alpha`,
+    ])
+
+    const desc = await gql<{ tasks: Array<{ patient: { lastname: string } | null }> }>(
+      request, token, query,
+      { rootLocationIds, assigneeId: me.id, filters, sorts: [{ fieldKey: 'patient', direction: 'DESC' }] }
+    )
+    expect(desc.tasks.map(t => t.patient?.lastname)).toEqual([
+      `${RUN_ID}-alpha`, `${RUN_ID}-mid`, `${RUN_ID}-zeta`,
+    ])
+  })
+
+  test('UI: login via the proxied keycloak and sort the patient list', async ({ page, request }) => {
+    await page.addInitScript((ids) => {
+      window.localStorage.setItem('selected-root-location-ids', JSON.stringify(ids))
+    }, seeded.rootLocationIds)
+
+    await page.goto(`${BASE}/`)
+    await page.waitForURL('**/keycloak/realms/tasks/**', { timeout: 30000 })
+    await page.locator('#username').fill(USERNAME)
+    await page.locator('#password').fill(PASSWORD)
+    await page.locator('#kc-login').click()
+    await page.waitForURL((url) => url.pathname === '/', { timeout: 30000 })
+
+    await page.goto(`${BASE}/patients`)
+    await expect(page.locator(ROW_SELECTOR).first()).toBeVisible({ timeout: 30000 })
+
+    await page.getByPlaceholder('Search').fill(RUN_ID)
+    await expect.poll(() => page.locator(ROW_SELECTOR).count(), { timeout: 20000 }).toBe(3)
+
+    await openSortingPanel(page)
+    await addSorting(page, 'Name')
+    await expect.poll(async () => {
+      const names = await visibleRowFirstCells(page)
+      return names.map(n => n.includes('-alpha') ? 'alpha' : n.includes('-mid') ? 'mid' : n.includes('-zeta') ? 'zeta' : n)
+    }, { timeout: 20000 }).toEqual(['alpha', 'mid', 'zeta'])
+
+    await setSortDirection(page, 'Name', 'DESC')
+    await expect.poll(async () => {
+      const names = await visibleRowFirstCells(page)
+      return names.map(n => n.includes('-alpha') ? 'alpha' : n.includes('-mid') ? 'mid' : n.includes('-zeta') ? 'zeta' : n)
+    }, { timeout: 20000 }).toEqual(['zeta', 'mid', 'alpha'])
+  })
+})


### PR DESCRIPTION
# Full-stack e2e behind the nginx proxy + a real backend sort crash it caught

Follow-up to #319: the mock-based e2e can't see routing or database-level problems, so this adds a second e2e tier that runs against the **real stack** — the docker images built for the current commit, wired together exactly like production (nginx proxy in front of web, backend and Keycloak).

## Proxied full-stack e2e

- **`docker-compose.e2e.yml`** — production-like stack (proxy → web / backend / Keycloak / Postgres / Redis / InfluxDB) with parameterized image references (`BACKEND_IMAGE` / `WEB_IMAGE` / `PROXY_IMAGE`) so CI runs this commit's images; ephemeral volumes, `restart: on-failure` on the backend so migrations retry until Postgres accepts connections.
- **`tests/e2e/proxy-fullstack.spec.ts`** (gated behind `E2E_PROXY_TARGET=1`, skipped in the mock-based runs):
  - proxy routing: `/` → web, `/keycloak/...` → Keycloak (issuer under the subpath), `/graphql` → backend (JSON, never the frontend catch-all)
  - authentication through the proxied Keycloak: password grant for API seeding **and** the real browser login flow (redirect → login form → `/auth/callback` → app)
  - seeds patients + tasks over the proxied GraphQL API, then asserts **server-side filtering and sorting from the real query engine**: name asc/desc, birthdate, `NOT_CONTAINS`, update-date sort, and sorting tasks by patient asc/desc (issue #213)
  - UI: logs in, searches, and sorts the patient list through the whole stack
- **`e2e-proxy` CI job** (tests.yml) — builds the backend/web/proxy images for the commit with Buildx (`cache-from/to: type=gha`, same scopes now written by the Docker Build workflow, so layers are shared with the images built earlier), starts the compose stack, waits for readiness through the proxy, runs the spec, and uploads the report + stack logs on failure. Added to the required `CI` gate.
- `E2E_TESTING.md` documents how to run this locally.

## Real bug the proxied tests caught (issue #213)

Sorting *my tasks* by patient crashed on PostgreSQL:

```
(sqlalchemy) for SELECT DISTINCT, ORDER BY expressions must appear in select list
```

The tasks/patients base queries use `SELECT DISTINCT` (location-scope joins), and every sort that orders by a joined or correlated expression — tasks by **patient** or assignee, patients by **update date**, **ward/room/bed**, clinic or position — produced an `ORDER BY` outside the select list and 500ed. This is invisible to the mock-based suite and to SQLite-backed tests; it reproduced immediately against the real Postgres backend through the proxy.

**Fix:** `apply_unified_query` now rewraps DISTINCT statements into a plain select over deduplicated ids before applying sorts (and clears stale join memos so sort adapters re-join the rewrapped statement). This also covers the pre-existing case where a property filter (`needs_distinct`) was combined with a position/clinic sort.

## Verification

- All 5 proxied tests pass locally against the compose stack built from this commit (they fail on `main` with the DISTINCT crash when sorting tasks by patient).
- Backend: `ruff` clean; unit tests show no new failures.
- The spec is skipped without `E2E_PROXY_TARGET=1`, so the existing mock-based e2e job is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCSmjBuS6NbcB6oRmKvQgT

---
_Generated by [Claude Code](https://claude.ai/code/session_01WCSmjBuS6NbcB6oRmKvQgT)_